### PR TITLE
perf: move full connect trajectory reconstruction and batched costs into Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ See [`docs/rewrite-plan.md`](docs/rewrite-plan.md) for the design and
   self-describing bundle.
 - **Visualization** — 3D rendering of the tree, trajectories, robot, and
   obstacles, with optional live updates during tree growth (headless supported).
-- **Rust hot path (optional)** — a `krrtstar_core` extension accelerates the
-  Euclidean neighbor pre-filter and linear connection cost; the package falls
-  back to pure Python when it is not built.
+- **Rust hot path (optional)** — a `krrtstar_core` extension runs the whole
+  connection in native code: the Euclidean neighbor pre-filter, batched
+  connection costs (sharing a precomputed time grid), and full trajectory
+  reconstruction. The package falls back to pure Python when it is not built.
 - **Learned dynamics (best-effort)** — an optional PyTorch backend steers via
   gradient/shooting and is treated as best-effort.
 

--- a/docs/rewrite-plan.md
+++ b/docs/rewrite-plan.md
@@ -380,13 +380,34 @@ An initial working implementation of the full stack has landed (see the
 | Visualize trees/trajectories/robot/obstacles in 3D | Done — `viz.py` (PyVista), offscreen render verified |
 | Save/load experiment (tree, refs, hyper-params) | Done — `experiment.py` bundle (`tree.npz` + `config.toml` + `meta.json`) |
 | Tree growth with/without visualization | Done — headless by default; live `progress_cb` |
-| Rust for the hot path | Done — `krrtstar_core` (neighbor pre-filter + linear cost), wired into the planner, pure-Python fallback |
+| Rust for the hot path | Done — `krrtstar_core`: neighbor pre-filter, batched connection costs, and full trajectory reconstruction; wired into the planner with a pure-Python fallback |
 | Learned models best-effort | Done — `TorchDynamics` (gradient/shooting), best-effort |
 
-Tests: 20 passing + 1 skipped (Torch, when PyTorch is not installed). The Rust
-core accelerates the planner (example: ~24s → ~15s; test suite ~42s → ~10s).
+Tests: 26 passing + 1 skipped (Torch, when PyTorch is not installed).
 
-Follow-on work (not yet done): moving the full `connect` trajectory
-reconstruction into Rust (currently Python), richer geometry (meshes, oriented
-boxes, capsules), and asymptotic-optimality tuning of the connection radius
-schedule.
+### Hot-path performance
+
+The whole connection now runs natively. Two things mattered most:
+
+1. **Trajectory reconstruction in Rust.** The costate/state pair is propagated
+   through the composite affine system. Because sample times are uniform, one
+   matrix exponential of the per-step generator is computed and applied
+   repeatedly, instead of one exponential per sample (~7.5x faster `connect`).
+2. **Batched cost queries with a shared time grid.** `Phi(t)`, `Ad(t)` and the
+   Gramian `G(t)` depend only on `(A, Q, t)` — never on the endpoint states — so
+   `LinearConnector` precomputes them once per system and reuses them for every
+   query. Profiling showed cost queries (24k calls) dominated at ~89% of
+   runtime; batching removed nearly all of it.
+
+End-to-end on `examples/double_integrator_2d.toml` (identical solution cost):
+
+| Stage | Wall time |
+|-------|-----------|
+| Pure Python | ~24s |
+| Rust cost + Python reconstruction | ~15s |
+| Rust reconstruction | ~10s |
+| Rust batched cost + reconstruction | **~1.5s** |
+
+Follow-on work (not yet done): richer geometry (meshes, oriented boxes,
+capsules), moving collision checking into Rust, and asymptotic-optimality tuning
+of the connection-radius schedule.

--- a/krrtstar/accel.py
+++ b/krrtstar/accel.py
@@ -55,3 +55,79 @@ def linear_cost(
         np.ascontiguousarray(x1, float).reshape(-1),
         float(tau_max),
     )
+
+
+def make_connector(
+    A: np.ndarray,
+    B: np.ndarray,
+    Rinv: np.ndarray,
+    c: np.ndarray,
+    tau_max: float,
+    n_samples: int,
+    grid_n: int = 64,
+):
+    """Create a reusable native connector for one linear system.
+
+    The connector precomputes the time-grid matrix exponentials once, so batched
+    cost queries need no further exponentials. Returns ``None`` when the native
+    core is unavailable.
+    """
+    if not HAVE_RUST:
+        return None
+    try:
+        return _core.LinearConnector(
+            np.ascontiguousarray(A, float),
+            np.ascontiguousarray(B, float),
+            np.ascontiguousarray(Rinv, float),
+            np.ascontiguousarray(c, float).reshape(-1),
+            float(tau_max),
+            int(n_samples),
+            int(grid_n),
+        )
+    except Exception:  # pragma: no cover - older core builds
+        return None
+
+
+def unpack_connect(result, x_dim: int, u_dim: int):
+    """Reshape a native connect result into arrays, or ``None``."""
+    if result is None:
+        return None
+    tau, cost, times, states_flat, controls_flat = result
+    times = np.asarray(times, dtype=float)
+    states = np.asarray(states_flat, dtype=float).reshape(len(times), x_dim)
+    controls = np.asarray(controls_flat, dtype=float).reshape(len(times), u_dim)
+    return float(tau), float(cost), times, states, controls
+
+
+def linear_connect(
+    A: np.ndarray,
+    B: np.ndarray,
+    Rinv: np.ndarray,
+    c: np.ndarray,
+    x0: np.ndarray,
+    x1: np.ndarray,
+    tau_max: float,
+    n_samples: int,
+):
+    """Full optimal connection (time, cost, sampled trajectory) via Rust.
+
+    Returns ``(tau, cost, times, states, controls)`` with ``states`` shaped
+    ``(n_samples, x_dim)`` and ``controls`` shaped ``(n_samples, u_dim)``, or
+    ``None`` when the native core is unavailable or the states are not
+    connectable.
+    """
+    if not HAVE_RUST:
+        return None
+    result = _core.linear_connect(
+        np.ascontiguousarray(A, float),
+        np.ascontiguousarray(B, float),
+        np.ascontiguousarray(Rinv, float),
+        np.ascontiguousarray(c, float).reshape(-1),
+        np.ascontiguousarray(x0, float).reshape(-1),
+        np.ascontiguousarray(x1, float).reshape(-1),
+        float(tau_max),
+        int(n_samples),
+    )
+    return unpack_connect(
+        result, int(np.asarray(A).shape[0]), int(np.asarray(B).shape[1])
+    )

--- a/krrtstar/dynamics/linear.py
+++ b/krrtstar/dynamics/linear.py
@@ -43,6 +43,7 @@ class AnalyticLinearDynamics:
         u_bounds: Optional[np.ndarray] = None,
         tau_max: float = 20.0,
         n_traj_samples: int = 32,
+        use_accel: bool = True,
     ) -> None:
         A = np.asarray(A, dtype=float)
         B = np.asarray(B, dtype=float)
@@ -64,6 +65,8 @@ class AnalyticLinearDynamics:
         )
         self.tau_max = float(tau_max)
         self.n_traj_samples = int(n_traj_samples)
+        # Allows forcing the pure-Python reference path (used for parity tests).
+        self.use_accel = bool(use_accel)
 
         # Precompute the augmented generator used for the drift integral
         # expm([[A, I],[0,0]] t) -> top-left = e^{A t}, top-right = int_0^t e^{A s} ds
@@ -79,6 +82,15 @@ class AnalyticLinearDynamics:
         self._gram_gen[:n, :n] = -A
         self._gram_gen[:n, n:] = self.Q
         self._gram_gen[n:, n:] = A.T
+
+        # Reusable native connector (precomputed time-grid exponentials).
+        self._connector = (
+            accel.make_connector(
+                self.A, self.B, self.Rinv, self.c, self.tau_max, self.n_traj_samples
+            )
+            if self.use_accel
+            else None
+        )
 
     # ------------------------------------------------------------------ #
     # Core matrix integrals
@@ -150,9 +162,14 @@ class AnalyticLinearDynamics:
         x0 = np.asarray(x0, dtype=float).reshape(-1)
         x1 = np.asarray(x1, dtype=float).reshape(-1)
         # Prefer the native (Rust) solver for the hot-path cost query.
-        rust = accel.linear_cost(self.A, self.Q, self.c, x0, x1, self.tau_max)
-        if rust is not None and np.isfinite(rust):
-            return float(rust)
+        if self._connector is not None:
+            rust = self._connector.cost(x0, x1)
+            if rust is not None and np.isfinite(rust):
+                return float(rust)
+        elif self.use_accel:
+            rust = accel.linear_cost(self.A, self.Q, self.c, x0, x1, self.tau_max)
+            if rust is not None and np.isfinite(rust):
+                return float(rust)
         result = self._optimal_tau(x0, x1)
         if result is None:
             return None
@@ -161,12 +178,35 @@ class AnalyticLinearDynamics:
     def connect(self, x0: np.ndarray, x1: np.ndarray) -> Optional[Trajectory]:
         x0 = np.asarray(x0, dtype=float).reshape(-1)
         x1 = np.asarray(x1, dtype=float).reshape(-1)
+
+        # Full connection (arrival time, cost, and sampled trajectory) in Rust.
+        if self.use_accel:
+            if self._connector is not None:
+                native = accel.unpack_connect(
+                    self._connector.connect(x0, x1), self.x_dim, self.u_dim
+                )
+            else:
+                native = accel.linear_connect(
+                    self.A, self.B, self.Rinv, self.c, x0, x1,
+                    self.tau_max, self.n_traj_samples,
+                )
+            if native is not None:
+                tau, cost, times, states, controls = native
+                if np.isfinite(cost) and np.all(np.isfinite(states)):
+                    return Trajectory(
+                        tau=tau,
+                        cost=cost,
+                        times=times,
+                        states=states,
+                        controls=controls,
+                        feasible=self._bounds.satisfied(controls),
+                    )
+
         result = self._optimal_tau(x0, x1)
         if result is None:
             return None
         tau, cost = result
-        traj = self._reconstruct(tau, cost, x0, x1)
-        return traj
+        return self._reconstruct(tau, cost, x0, x1)
 
     # ------------------------------------------------------------------ #
     # Trajectory reconstruction
@@ -214,6 +254,38 @@ class AnalyticLinearDynamics:
             controls=controls,
             feasible=feasible,
         )
+
+    # ------------------------------------------------------------------ #
+    # Batched cost queries (planner ranking / filtering)
+    # ------------------------------------------------------------------ #
+    def cost_batch_to(self, states: np.ndarray, x1: np.ndarray) -> np.ndarray:
+        """Costs from each row of ``states`` to ``x1``.
+
+        Uses the native connector's precomputed time grid when available, which
+        avoids recomputing matrix exponentials per query. Unreachable pairs come
+        back as ``inf``.
+        """
+        states = np.ascontiguousarray(states, dtype=float)
+        x1 = np.asarray(x1, dtype=float).reshape(-1)
+        if self._connector is not None and states.shape[0] > 0:
+            return np.asarray(self._connector.cost_batch_to(states, x1), dtype=float)
+        return self._cost_loop(states, x1, reverse=False)
+
+    def cost_batch_from(self, x0: np.ndarray, states: np.ndarray) -> np.ndarray:
+        """Costs from ``x0`` to each row of ``states``."""
+        states = np.ascontiguousarray(states, dtype=float)
+        x0 = np.asarray(x0, dtype=float).reshape(-1)
+        if self._connector is not None and states.shape[0] > 0:
+            return np.asarray(self._connector.cost_batch_from(x0, states), dtype=float)
+        return self._cost_loop(states, x0, reverse=True)
+
+    def _cost_loop(self, states: np.ndarray, other: np.ndarray, reverse: bool) -> np.ndarray:
+        out = np.full(states.shape[0], np.inf)
+        for i, s in enumerate(states):
+            c = self.cost(other, s) if reverse else self.cost(s, other)
+            if c is not None and np.isfinite(c):
+                out[i] = c
+        return out
 
     def u_bounds(self) -> Optional[np.ndarray]:
         return self._bounds.bounds

--- a/krrtstar/planner.py
+++ b/krrtstar/planner.py
@@ -140,13 +140,15 @@ class KRRTStar:
         then invokes the expensive ``connect`` only in increasing cost order
         until a collision-free connection is found.
         """
+        idxs = self._candidate_indices(x_new)
+        if len(idxs) == 0:
+            return None
+        costs = self._batch_costs(idxs, x_new, to_target=True)
         ranked = []
-        for i in self._candidate_indices(x_new):
-            node = self.tree.nodes[i]
-            c = self.dyn.cost(node.state, x_new)
-            if c is None or c > self.radius:
+        for i, c in zip(idxs, costs):
+            if not np.isfinite(c) or c > self.radius:
                 continue
-            ranked.append((node.cost_from_start + c, i))
+            ranked.append((self.tree.nodes[i].cost_from_start + c, i))
         ranked.sort(key=lambda t: t[0])
         for _, i in ranked:
             node = self.tree.nodes[i]
@@ -156,15 +158,34 @@ class KRRTStar:
             return (i, traj, node.cost_from_start + traj.cost)
         return None
 
+    def _batch_costs(self, idxs, x, to_target: bool) -> np.ndarray:
+        """Connection costs between ``x`` and the given tree nodes.
+
+        Prefers the dynamics' batched query (native, shared time grid) and
+        falls back to per-pair ``cost`` calls for backends that lack it.
+        """
+        states = np.array([self.tree.nodes[i].state for i in idxs], dtype=float)
+        if to_target and hasattr(self.dyn, "cost_batch_to"):
+            return self.dyn.cost_batch_to(states, x)
+        if not to_target and hasattr(self.dyn, "cost_batch_from"):
+            return self.dyn.cost_batch_from(x, states)
+        out = np.full(len(idxs), np.inf)
+        for k, s in enumerate(states):
+            c = self.dyn.cost(s, x) if to_target else self.dyn.cost(x, s)
+            if c is not None and np.isfinite(c):
+                out[k] = c
+        return out
+
     def _rewire(self, new_idx: int) -> None:
         new_node = self.tree.nodes[new_idx]
         x_new = new_node.state
-        for i in self._candidate_indices(x_new):
-            if i == new_idx:
-                continue
+        idxs = [i for i in self._candidate_indices(x_new) if i != new_idx]
+        if not idxs:
+            return
+        costs = self._batch_costs(idxs, x_new, to_target=False)
+        for i, c in zip(idxs, costs):
             node = self.tree.nodes[i]
-            c = self.dyn.cost(x_new, node.state)
-            if c is None or c > self.radius:
+            if not np.isfinite(c) or c > self.radius:
                 continue
             if new_node.cost_from_start + c + 1e-9 >= node.cost_from_start:
                 continue

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,17 @@
+//! Native hot-path primitives for the krrtstar planner.
+//!
+//! Provides the optimal-time connection for linear systems
+//!     x_dot = A x + B u + c,   cost = integral_0^tau (1 + u^T R u) dt
+//! including full trajectory reconstruction, plus a Euclidean neighbour
+//! pre-filter.
+//!
+//! The key performance property exploited here: the matrix integrals
+//! `Phi(t) = e^{A t}`, `Ad(t) = int_0^t e^{A s} ds` and the weighted
+//! controllability Gramian `G(t)` depend only on `(A, Q, t)` -- never on the
+//! endpoint states. `LinearConnector` therefore precomputes them once on a
+//! fixed time grid and reuses them for every cost query, which turns each
+//! query into a handful of matrix-vector products.
+
 use nalgebra::{DMatrix, DVector};
 use numpy::{PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
@@ -48,24 +62,21 @@ fn euclidean_neighbors(
 /// pseudo-inverse if `G` is singular/ill-conditioned.
 fn robust_solve(g: &DMatrix<f64>, diff: &DVector<f64>) -> Option<DVector<f64>> {
     let n = g.nrows();
-    // Primary: LU decomposition.
     if let Some(sol) = g.clone().lu().solve(diff) {
         if sol.iter().all(|v| v.is_finite()) {
             return Some(sol);
         }
     }
-    // Regularized solve.
     let reg = 1e-9;
     let mut gr = g.clone();
     for i in 0..n {
         gr[(i, i)] += reg;
     }
-    if let Some(sol) = gr.clone().lu().solve(diff) {
+    if let Some(sol) = gr.lu().solve(diff) {
         if sol.iter().all(|v| v.is_finite()) {
             return Some(sol);
         }
     }
-    // Pseudo-inverse fallback.
     if let Ok(pinv) = g.clone().pseudo_inverse(1e-12) {
         let sol = pinv * diff;
         if sol.iter().all(|v| v.is_finite()) {
@@ -73,6 +84,64 @@ fn robust_solve(g: &DMatrix<f64>, diff: &DVector<f64>) -> Option<DVector<f64>> {
         }
     }
     None
+}
+
+/// `Phi(t)` and `Ad(t) = int_0^t e^{A s} ds` via one augmented exponential.
+fn phi_and_ad(a: &DMatrix<f64>, t: f64) -> (DMatrix<f64>, DMatrix<f64>) {
+    let n = a.nrows();
+    let mut drift = DMatrix::<f64>::zeros(2 * n, 2 * n);
+    drift.view_mut((0, 0), (n, n)).copy_from(a);
+    for i in 0..n {
+        drift[(i, n + i)] = 1.0;
+    }
+    let z = (drift * t).exp();
+    (
+        z.view((0, 0), (n, n)).into_owned(),
+        z.view((0, n), (n, n)).into_owned(),
+    )
+}
+
+/// Weighted controllability Gramian `G(t)` via Van Loan's method:
+/// `M = expm([[-A, Q],[0, A^T]] t)`, then `G = M22^T M12`.
+fn gramian(a: &DMatrix<f64>, q: &DMatrix<f64>, t: f64) -> DMatrix<f64> {
+    let n = a.nrows();
+    let mut gen = DMatrix::<f64>::zeros(2 * n, 2 * n);
+    gen.view_mut((0, 0), (n, n)).copy_from(&(-a));
+    gen.view_mut((0, n), (n, n)).copy_from(q);
+    gen.view_mut((n, n), (n, n)).copy_from(&a.transpose());
+    let m = (gen * t).exp();
+    let m12 = m.view((0, n), (n, n)).into_owned();
+    let m22 = m.view((n, n), (n, n)).into_owned();
+    m22.transpose() * m12
+}
+
+/// Cost at a fixed arrival time `t`, together with the costate vector `d`.
+///
+/// `d = G(t)^{-1} (x1 - xbar(t))` is needed both for the cost and to
+/// reconstruct the optimal control, so it is returned to avoid recomputation.
+fn cost_and_costate(
+    a: &DMatrix<f64>,
+    q: &DMatrix<f64>,
+    c: &DVector<f64>,
+    x0: &DVector<f64>,
+    x1: &DVector<f64>,
+    t: f64,
+) -> (f64, Option<DVector<f64>>) {
+    let (phi, ad) = phi_and_ad(a, t);
+    let xbar = &phi * x0 + &ad * c;
+    let g = gramian(a, q, t);
+    let diff = x1 - xbar;
+    match robust_solve(&g, &diff) {
+        Some(d) => {
+            let cost = t + diff.dot(&d);
+            if cost.is_finite() {
+                (cost, Some(d))
+            } else {
+                (f64::INFINITY, None)
+            }
+        }
+        None => (f64::INFINITY, None),
+    }
 }
 
 /// Cost at a fixed arrival time `t` for the linear connection problem.
@@ -84,43 +153,191 @@ fn cost_at(
     x1: &DVector<f64>,
     t: f64,
 ) -> f64 {
-    let n = a.nrows();
+    cost_and_costate(a, q, c, x0, x1, t).0
+}
 
-    // Drift generator: expm([[A, I],[0, 0]] * t) -> top-left = Phi, top-right = Ad.
-    let mut drift = DMatrix::<f64>::zeros(2 * n, 2 * n);
-    drift.view_mut((0, 0), (n, n)).copy_from(a);
-    for i in 0..n {
-        drift[(i, n + i)] = 1.0;
+/// Find the optimal arrival time by a coarse global scan followed by a
+/// golden-section refinement inside the best bracket.
+///
+/// The coarse scan guards against the cost curve's local minima (a pure
+/// golden-section search assumes unimodality, which does not always hold).
+fn optimal_tau(
+    a: &DMatrix<f64>,
+    q: &DMatrix<f64>,
+    c: &DVector<f64>,
+    x0: &DVector<f64>,
+    x1: &DVector<f64>,
+    tau_max: f64,
+) -> Option<(f64, f64)> {
+    let eps = 1e-4;
+    if tau_max <= eps {
+        return None;
     }
-    let z = (drift * t).exp();
-    let phi = z.view((0, 0), (n, n)).into_owned();
-    let ad = z.view((0, n), (n, n)).into_owned();
-    let xbar = &phi * x0 + &ad * c;
 
-    // Van Loan generator for the Gramian:
-    // M = expm([[-A, Q],[0, A^T]] * t); G = M22^T @ M12.
-    let mut gram_gen = DMatrix::<f64>::zeros(2 * n, 2 * n);
-    gram_gen.view_mut((0, 0), (n, n)).copy_from(&(-a));
-    gram_gen.view_mut((0, n), (n, n)).copy_from(q);
-    gram_gen.view_mut((n, n), (n, n)).copy_from(&a.transpose());
-    let m = (gram_gen * t).exp();
-    let m12 = m.view((0, n), (n, n)).into_owned();
-    let m22 = m.view((n, n), (n, n)).into_owned();
-    let g = m22.transpose() * m12;
-
-    let diff = x1 - xbar;
-    match robust_solve(&g, &diff) {
-        Some(d) => {
-            let quad = diff.dot(&d);
-            let cost = t + quad;
-            if cost.is_finite() {
-                cost
-            } else {
-                f64::INFINITY
-            }
+    let objective = |t: f64| -> f64 {
+        if t <= eps {
+            return f64::INFINITY;
         }
-        None => f64::INFINITY,
+        let cost = cost_at(a, q, c, x0, x1, t);
+        if !cost.is_finite() || cost <= 0.0 {
+            f64::INFINITY
+        } else {
+            cost
+        }
+    };
+
+    let grid_n = 48usize;
+    let mut best_t = f64::NAN;
+    let mut best_f = f64::INFINITY;
+    let mut grid = Vec::with_capacity(grid_n);
+    for k in 0..grid_n {
+        let t = eps + (tau_max - eps) * (k as f64) / ((grid_n - 1) as f64);
+        let f = objective(t);
+        grid.push((t, f));
+        if f < best_f {
+            best_f = f;
+            best_t = t;
+        }
     }
+    if !best_f.is_finite() {
+        return None;
+    }
+
+    let k_best = grid.iter().position(|&(t, _)| t == best_t).unwrap_or(0);
+    let mut lo = grid[k_best.saturating_sub(1)].0;
+    let mut hi = grid[(k_best + 1).min(grid_n - 1)].0;
+    if hi <= lo {
+        return Some((best_t, best_f));
+    }
+
+    refine_golden(&objective, lo, hi, &mut best_t, &mut best_f);
+    let _ = (&mut lo, &mut hi);
+    if best_f.is_finite() {
+        Some((best_t, best_f))
+    } else {
+        None
+    }
+}
+
+/// Golden-section refinement of `objective` on `[lo, hi]`, updating the best
+/// point found so far.
+fn refine_golden<F: Fn(f64) -> f64>(
+    objective: &F,
+    mut lo: f64,
+    mut hi: f64,
+    best_t: &mut f64,
+    best_f: &mut f64,
+) {
+    let inv_phi = (5.0f64.sqrt() - 1.0) / 2.0; // 1/phi ~= 0.618
+    let mut p1 = hi - inv_phi * (hi - lo);
+    let mut p2 = lo + inv_phi * (hi - lo);
+    let mut f1 = objective(p1);
+    let mut f2 = objective(p2);
+    for _ in 0..80 {
+        if f1 <= f2 {
+            hi = p2;
+            p2 = p1;
+            f2 = f1;
+            p1 = hi - inv_phi * (hi - lo);
+            f1 = objective(p1);
+        } else {
+            lo = p1;
+            p1 = p2;
+            f1 = f2;
+            p2 = lo + inv_phi * (hi - lo);
+            f2 = objective(p2);
+        }
+        if (hi - lo).abs() < 1e-7 {
+            break;
+        }
+    }
+    for &(t, f) in [(p1, f1), (p2, f2)].iter() {
+        if f < *best_f {
+            *best_f = f;
+            *best_t = t;
+        }
+    }
+}
+
+/// Reconstruct the sampled optimal state/control trajectory for a known
+/// arrival time.
+///
+/// The optimal control is `u(t) = R^{-1} B^T y(t)` with costate
+/// `y(t) = e^{A^T (tau - t)} d`. States and costates are propagated together
+/// through the composite system
+///     d/dt [x; y] = [[A, Q],[0, -A^T]] [x; y] + [c; 0],
+/// embedded in an affine `(2n+1)` generator. Because the sample times are
+/// uniform, a single matrix exponential of the per-step generator is computed
+/// once and applied repeatedly, instead of one exponential per sample.
+#[allow(clippy::too_many_arguments)]
+fn reconstruct(
+    a: &DMatrix<f64>,
+    b: &DMatrix<f64>,
+    rinv: &DMatrix<f64>,
+    q: &DMatrix<f64>,
+    c: &DVector<f64>,
+    x0: &DVector<f64>,
+    x1: &DVector<f64>,
+    tau: f64,
+    n_samples: usize,
+) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>)> {
+    let n = a.nrows();
+    let u_dim = b.ncols();
+    let samples = n_samples.max(2);
+
+    let d = cost_and_costate(a, q, c, x0, x1, tau).1?;
+
+    let dim = 2 * n + 1;
+    let mut comp = DMatrix::<f64>::zeros(dim, dim);
+    comp.view_mut((0, 0), (n, n)).copy_from(a);
+    comp.view_mut((0, n), (n, n)).copy_from(q);
+    comp.view_mut((n, n), (n, n)).copy_from(&(-a.transpose()));
+    for i in 0..n {
+        comp[(i, 2 * n)] = c[i];
+    }
+
+    let y0 = (a.transpose() * tau).exp() * &d;
+
+    let mut z = DVector::<f64>::zeros(dim);
+    for i in 0..n {
+        z[i] = x0[i];
+        z[n + i] = y0[i];
+    }
+    z[2 * n] = 1.0;
+
+    let dt = tau / ((samples - 1) as f64);
+    let step = (comp * dt).exp();
+    let rinv_bt = rinv * b.transpose();
+
+    let mut times = Vec::with_capacity(samples);
+    let mut states = Vec::with_capacity(samples * n);
+    let mut controls = Vec::with_capacity(samples * u_dim);
+
+    for k in 0..samples {
+        times.push(dt * (k as f64));
+        for i in 0..n {
+            states.push(z[i]);
+        }
+        let y = DVector::from_fn(n, |i, _| z[n + i]);
+        let u = &rinv_bt * y;
+        for j in 0..u_dim {
+            controls.push(u[j]);
+        }
+        if k + 1 < samples {
+            z = &step * &z;
+        }
+    }
+
+    // Pin endpoints exactly (guards against small numerical drift).
+    for i in 0..n {
+        states[i] = x0[i];
+        states[(samples - 1) * n + i] = x1[i];
+    }
+    if let Some(last) = times.last_mut() {
+        *last = tau;
+    }
+
+    Some((times, states, controls))
 }
 
 /// Optimal-time linear connection cost, or None if not connectable.
@@ -138,65 +355,225 @@ fn linear_cost(
     let c = to_dvector(&c);
     let x0 = to_dvector(&x0);
     let x1 = to_dvector(&x1);
+    Ok(optimal_tau(&a, &q, &c, &x0, &x1, tau_max).map(|(_, cost)| cost))
+}
 
-    let eps = 1e-4;
-    if tau_max <= eps {
-        return Ok(None);
-    }
+/// Full optimal connection: arrival time, cost, and the sampled optimal
+/// state/control trajectory.
+///
+/// Returns `(tau, cost, times, states_flat, controls_flat)` where the flat
+/// vectors are row-major with shapes `(n_samples, x_dim)` and
+/// `(n_samples, u_dim)`. Returns `None` if the states cannot be connected.
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+fn linear_connect(
+    a: PyReadonlyArray2<f64>,
+    b: PyReadonlyArray2<f64>,
+    rinv: PyReadonlyArray2<f64>,
+    c: PyReadonlyArray1<f64>,
+    x0: PyReadonlyArray1<f64>,
+    x1: PyReadonlyArray1<f64>,
+    tau_max: f64,
+    n_samples: usize,
+) -> PyResult<Option<(f64, f64, Vec<f64>, Vec<f64>, Vec<f64>)>> {
+    let a = to_dmatrix(&a);
+    let b = to_dmatrix(&b);
+    let rinv = to_dmatrix(&rinv);
+    let c = to_dvector(&c);
+    let x0 = to_dvector(&x0);
+    let x1 = to_dvector(&x1);
+    let q = &b * &rinv * b.transpose();
 
-    let objective = |t: f64| -> f64 {
-        if t <= eps {
-            return f64::INFINITY;
-        }
-        let cost = cost_at(&a, &q, &c, &x0, &x1, t);
-        if !cost.is_finite() || cost <= 0.0 {
-            f64::INFINITY
-        } else {
-            cost
-        }
+    let (tau, cost) = match optimal_tau(&a, &q, &c, &x0, &x1, tau_max) {
+        Some(v) => v,
+        None => return Ok(None),
     };
+    match reconstruct(&a, &b, &rinv, &q, &c, &x0, &x1, tau, n_samples) {
+        Some((times, states, controls)) => Ok(Some((tau, cost, times, states, controls))),
+        None => Ok(None),
+    }
+}
 
-    // Golden-section search over [eps, tau_max].
-    let inv_phi = (5.0f64.sqrt() - 1.0) / 2.0; // 1/phi ~= 0.618
-    let mut lo = eps;
-    let mut hi = tau_max;
-    let mut x1p = hi - inv_phi * (hi - lo);
-    let mut x2p = lo + inv_phi * (hi - lo);
-    let mut f1 = objective(x1p);
-    let mut f2 = objective(x2p);
-    for _ in 0..100 {
-        if f1 <= f2 {
-            hi = x2p;
-            x2p = x1p;
-            f2 = f1;
-            x1p = hi - inv_phi * (hi - lo);
-            f1 = objective(x1p);
-        } else {
-            lo = x1p;
-            x1p = x2p;
-            f1 = f2;
-            x2p = lo + inv_phi * (hi - lo);
-            f2 = objective(x2p);
+/// Precomputed per-time-step matrices shared by all cost queries.
+struct GridPoint {
+    t: f64,
+    phi: DMatrix<f64>,
+    ad_c: DVector<f64>,
+    ginv: DMatrix<f64>,
+}
+
+/// Regularized inverse; falls back to a pseudo-inverse.
+///
+/// A small relative regularization makes unreachable directions produce very
+/// large costs (so they are filtered out) rather than the artificially small
+/// cost a bare pseudo-inverse would report.
+fn reg_inverse(g: &DMatrix<f64>) -> Option<DMatrix<f64>> {
+    let n = g.nrows();
+    let scale = g.trace().abs().max(1.0);
+    let mut gr = g.clone();
+    for i in 0..n {
+        gr[(i, i)] += 1e-12 * scale;
+    }
+    if let Some(inv) = gr.try_inverse() {
+        if inv.iter().all(|v| v.is_finite()) {
+            return Some(inv);
         }
     }
+    g.clone().pseudo_inverse(1e-12).ok()
+}
 
-    // Best over the final bracket plus the sampled endpoints.
-    let candidates = [
-        (x1p, f1),
-        (x2p, f2),
-        ((lo + hi) / 2.0, objective((lo + hi) / 2.0)),
-    ];
-    let mut best = f64::INFINITY;
-    for &(_, f) in candidates.iter() {
-        if f < best {
-            best = f;
+/// A reusable connector for one linear system.
+///
+/// Holds the system matrices plus a precomputed time grid, so batched cost
+/// queries avoid recomputing any matrix exponentials.
+#[pyclass]
+struct LinearConnector {
+    a: DMatrix<f64>,
+    b: DMatrix<f64>,
+    rinv: DMatrix<f64>,
+    q: DMatrix<f64>,
+    c: DVector<f64>,
+    tau_max: f64,
+    n_samples: usize,
+    grid: Vec<GridPoint>,
+}
+
+#[pymethods]
+impl LinearConnector {
+    #[new]
+    #[pyo3(signature = (a, b, rinv, c, tau_max, n_samples, grid_n = 64))]
+    fn new(
+        a: PyReadonlyArray2<f64>,
+        b: PyReadonlyArray2<f64>,
+        rinv: PyReadonlyArray2<f64>,
+        c: PyReadonlyArray1<f64>,
+        tau_max: f64,
+        n_samples: usize,
+        grid_n: usize,
+    ) -> PyResult<Self> {
+        let a = to_dmatrix(&a);
+        let b = to_dmatrix(&b);
+        let rinv = to_dmatrix(&rinv);
+        let c = to_dvector(&c);
+        let q = &b * &rinv * b.transpose();
+
+        let eps = 1e-4;
+        let grid_n = grid_n.max(2);
+        let mut grid = Vec::with_capacity(grid_n);
+        for k in 0..grid_n {
+            let t = eps + (tau_max - eps) * (k as f64) / ((grid_n - 1) as f64);
+            let (phi, ad) = phi_and_ad(&a, t);
+            let g = gramian(&a, &q, t);
+            if let Some(ginv) = reg_inverse(&g) {
+                grid.push(GridPoint {
+                    t,
+                    phi,
+                    ad_c: ad * &c,
+                    ginv,
+                });
+            }
         }
+
+        Ok(Self {
+            a,
+            b,
+            rinv,
+            q,
+            c,
+            tau_max,
+            n_samples,
+            grid,
+        })
     }
 
-    if best.is_finite() {
-        Ok(Some(best))
-    } else {
-        Ok(None)
+    /// Grid-approximated optimal cost from each row of `states` to `x1`.
+    ///
+    /// Returns one cost per row (`f64::INFINITY` when not connectable). This is
+    /// the planner's ranking/filtering query: it reuses the precomputed grid,
+    /// so no matrix exponentials are taken here.
+    fn cost_batch_to(
+        &self,
+        states: PyReadonlyArray2<f64>,
+        x1: PyReadonlyArray1<f64>,
+    ) -> PyResult<Vec<f64>> {
+        let s = states.as_array();
+        let x1 = to_dvector(&x1);
+        let n = self.a.nrows();
+        let rows = s.nrows();
+        let mut out = Vec::with_capacity(rows);
+
+        for i in 0..rows {
+            let x0 = DVector::from_fn(n, |j, _| s[[i, j]]);
+            let mut best = f64::INFINITY;
+            for gp in &self.grid {
+                let xbar = &gp.phi * &x0 + &gp.ad_c;
+                let diff = &x1 - xbar;
+                let d = &gp.ginv * &diff;
+                let cost = gp.t + diff.dot(&d);
+                if cost.is_finite() && cost > 0.0 && cost < best {
+                    best = cost;
+                }
+            }
+            out.push(best);
+        }
+        Ok(out)
+    }
+
+    /// Grid-approximated optimal cost from `x0` to each row of `states`.
+    ///
+    /// The drift `xbar(t)` depends only on `x0`, so it is computed once per
+    /// grid point and reused across all targets.
+    fn cost_batch_from(
+        &self,
+        x0: PyReadonlyArray1<f64>,
+        states: PyReadonlyArray2<f64>,
+    ) -> PyResult<Vec<f64>> {
+        let x0 = to_dvector(&x0);
+        let s = states.as_array();
+        let n = self.a.nrows();
+        let rows = s.nrows();
+        let mut out = vec![f64::INFINITY; rows];
+
+        for gp in &self.grid {
+            let xbar = &gp.phi * &x0 + &gp.ad_c;
+            for i in 0..rows {
+                let diff = DVector::from_fn(n, |j, _| s[[i, j]] - xbar[j]);
+                let d = &gp.ginv * &diff;
+                let cost = gp.t + diff.dot(&d);
+                if cost.is_finite() && cost > 0.0 && cost < out[i] {
+                    out[i] = cost;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Refined optimal cost for a single pair (grid scan + golden section).
+    fn cost(&self, x0: PyReadonlyArray1<f64>, x1: PyReadonlyArray1<f64>) -> PyResult<Option<f64>> {
+        let x0 = to_dvector(&x0);
+        let x1 = to_dvector(&x1);
+        Ok(optimal_tau(&self.a, &self.q, &self.c, &x0, &x1, self.tau_max).map(|(_, cost)| cost))
+    }
+
+    /// Full connection with trajectory reconstruction.
+    fn connect(
+        &self,
+        x0: PyReadonlyArray1<f64>,
+        x1: PyReadonlyArray1<f64>,
+    ) -> PyResult<Option<(f64, f64, Vec<f64>, Vec<f64>, Vec<f64>)>> {
+        let x0 = to_dvector(&x0);
+        let x1 = to_dvector(&x1);
+        let (tau, cost) =
+            match optimal_tau(&self.a, &self.q, &self.c, &x0, &x1, self.tau_max) {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+        match reconstruct(
+            &self.a, &self.b, &self.rinv, &self.q, &self.c, &x0, &x1, tau, self.n_samples,
+        ) {
+            Some((times, states, controls)) => Ok(Some((tau, cost, times, states, controls))),
+            None => Ok(None),
+        }
     }
 }
 
@@ -204,5 +581,7 @@ fn linear_cost(
 fn krrtstar_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(euclidean_neighbors, m)?)?;
     m.add_function(wrap_pyfunction!(linear_cost, m)?)?;
+    m.add_function(wrap_pyfunction!(linear_connect, m)?)?;
+    m.add_class::<LinearConnector>()?;
     Ok(())
 }

--- a/tests/test_accel_parity.py
+++ b/tests/test_accel_parity.py
@@ -30,3 +30,140 @@ def test_rust_linear_cost_matches_python():
         py = dyn._optimal_tau(x0, x1)
         assert rust is not None and py is not None
         assert rust == pytest.approx(py[1], rel=1e-2, abs=1e-2)
+
+
+def double_integrator_2d():
+    A = np.array(
+        [[0.0, 0.0, 1.0, 0.0],
+         [0.0, 0.0, 0.0, 1.0],
+         [0.0, 0.0, 0.0, 0.0],
+         [0.0, 0.0, 0.0, 0.0]]
+    )
+    B = np.array([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    return A, B
+
+
+@pytest.mark.skipif(not accel.HAVE_RUST, reason="Rust core not built")
+def test_rust_connect_matches_python_reconstruction():
+    """Native trajectory reconstruction must match the Python reference."""
+    A, B = double_integrator_2d()
+    R = np.eye(2)
+    rust = AnalyticLinearDynamics(A, B, R=R, n_traj_samples=64, use_accel=True)
+    py = AnalyticLinearDynamics(A, B, R=R, n_traj_samples=64, use_accel=False)
+    rng = np.random.default_rng(0)
+    for _ in range(8):
+        x0 = rng.uniform(-3, 3, size=4)
+        x1 = rng.uniform(-3, 3, size=4)
+        tr = rust.connect(x0, x1)
+        tp = py.connect(x0, x1)
+        assert tr is not None and tp is not None
+        assert tr.tau == pytest.approx(tp.tau, rel=1e-3, abs=1e-3)
+        assert tr.cost == pytest.approx(tp.cost, rel=1e-4, abs=1e-4)
+        assert tr.times.shape == tp.times.shape
+        assert np.allclose(tr.states, tp.states, atol=1e-3)
+        assert np.allclose(tr.controls, tp.controls, atol=1e-3)
+
+
+@pytest.mark.skipif(not accel.HAVE_RUST, reason="Rust core not built")
+def test_native_connect_trajectory_is_physically_consistent():
+    """The native trajectory must satisfy the ODE, endpoints, and cost identity."""
+    A, B = double_integrator_2d()
+    R = np.eye(2)
+    dyn = AnalyticLinearDynamics(A, B, R=R, n_traj_samples=400, use_accel=True)
+    x0 = np.array([-1.0, 0.5, 0.2, -0.3])
+    x1 = np.array([2.0, -1.0, 0.0, 0.0])
+    traj = dyn.connect(x0, x1)
+    assert traj is not None
+    # endpoints
+    assert np.allclose(traj.states[0], x0, atol=1e-9)
+    assert np.allclose(traj.states[-1], x1, atol=1e-9)
+    # cost identity: cost == tau + control effort
+    effort = np.trapezoid(
+        np.einsum("ti,ij,tj->t", traj.controls, R, traj.controls), traj.times
+    )
+    assert traj.cost == pytest.approx(traj.tau + effort, rel=1e-3, abs=1e-3)
+    # satisfies xdot = A x + B u
+    xdot_fd = np.gradient(traj.states, traj.times, axis=0)
+    xdot_dyn = (A @ traj.states.T + B @ traj.controls.T).T
+    assert np.max(np.abs(xdot_fd - xdot_dyn)[3:-3]) < 1e-3
+
+
+def test_batched_costs_agree_with_pairwise():
+    """Batched grid costs must bound and closely track the refined costs."""
+    A, B = double_integrator_2d()
+    dyn = AnalyticLinearDynamics(A, B, R=np.eye(2))
+    rng = np.random.default_rng(3)
+    states = rng.uniform(-3, 3, size=(12, 4))
+    target = np.array([1.0, -1.0, 0.0, 0.0])
+
+    batch_to = dyn.cost_batch_to(states, target)
+    pair_to = np.array([dyn.cost(s, target) for s in states], dtype=float)
+    # The grid scan cannot beat the refined optimum, and should be close to it.
+    assert np.all(batch_to >= pair_to - 1e-6)
+    assert np.allclose(batch_to, pair_to, rtol=0.05, atol=0.05)
+
+    batch_from = dyn.cost_batch_from(target, states)
+    pair_from = np.array([dyn.cost(target, s) for s in states], dtype=float)
+    assert np.all(batch_from >= pair_from - 1e-6)
+    assert np.allclose(batch_from, pair_from, rtol=0.05, atol=0.05)
+
+
+def test_batched_costs_match_python_fallback():
+    """The pure-Python batch fallback must agree with the native batch."""
+    A, B = double_integrator_2d()
+    fast = AnalyticLinearDynamics(A, B, R=np.eye(2), use_accel=True)
+    slow = AnalyticLinearDynamics(A, B, R=np.eye(2), use_accel=False)
+    rng = np.random.default_rng(4)
+    states = rng.uniform(-2, 2, size=(6, 4))
+    target = np.array([0.5, 0.5, 0.0, 0.0])
+    a = fast.cost_batch_to(states, target)
+    b = slow.cost_batch_to(states, target)
+    assert np.allclose(a, b, rtol=0.05, atol=0.05)
+
+
+def test_planner_works_with_dynamics_lacking_batch_methods():
+    """Backends without batched cost (e.g. learned models) still plan."""
+    from krrtstar.planner import KRRTStar
+
+    base = AnalyticLinearDynamics(np.zeros((2, 2)), np.eye(2))
+
+    class NoBatch:
+        """Minimal Dynamics implementation exposing only the protocol methods."""
+
+        x_dim = 2
+        u_dim = 2
+
+        def cost(self, x0, x1):
+            return base.cost(x0, x1)
+
+        def connect(self, x0, x1):
+            return base.connect(x0, x1)
+
+        def u_bounds(self):
+            return None
+
+    dyn = NoBatch()
+    assert not hasattr(dyn, "cost_batch_to")
+    planner = KRRTStar(
+        dynamics=dyn,
+        state_bounds=np.array([[-4, -4], [4, 4]]),
+        x_init=np.array([-3.0, -3.0]),
+        x_goal=np.array([3.0, 3.0]),
+        connection_radius=8.0,
+        euclidean_gate=8.0,
+        seed=2,
+    )
+    result = planner.grow(60)
+    assert len(result.tree.nodes) > 1
+
+
+@pytest.mark.skipif(not accel.HAVE_RUST, reason="Rust core not built")
+def test_native_connect_respects_control_bounds_flag():
+    A, B = double_integrator_2d()
+    dyn = AnalyticLinearDynamics(
+        A, B, u_bounds=np.array([[-1e-3, 1e-3], [-1e-3, 1e-3]]), use_accel=True
+    )
+    traj = dyn.connect(np.zeros(4), np.array([5.0, 5.0, 0.0, 0.0]))
+    assert traj is not None
+    assert traj.feasible is False
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the follow-on work from [#4](https://github.com/daemonmaker/krrtstar/pull/4) (now merged): the **full `connect` trajectory reconstruction now runs in Rust**.

Profiling after the reconstruction change revealed the bottleneck had *moved*, so this PR also removes the new one. End result: the example planner goes from **~15s to ~1.5s** with an identical solution.

## 1. Native trajectory reconstruction

`linear_connect` reconstructs the optimal state/control trajectory by propagating the composite (state, costate) system

```
d/dt [x; y] = [[A, Q], [0, -A^T]] [x; y] + [c; 0],   u(t) = R^-1 B^T y(t)
```

embedded in an affine `(2n+1)` generator. Because the sample times are uniform, **one** matrix exponential of the per-step generator is computed and applied repeatedly, instead of one exponential per sample as the Python version did. That alone made `connect` **~7.5x faster**.

## 2. Batched costs with a shared time grid

Profiling then showed cost queries dominated: 24,113 calls at 8.66s (**89% of runtime**), versus only 0.55s for `connect`.

The key observation: `Phi(t)`, `Ad(t)`, and the Gramian `G(t)` depend only on `(A, Q, t)` — **never on the endpoint states**. A new stateful `LinearConnector` precomputes them once on a time grid and reuses them for every query, so batched cost evaluation takes no matrix exponentials at all. It exposes both directions needed by the planner (`cost_batch_to` for parent selection, `cost_batch_from` for rewiring), and the planner now ranks candidates through them.

## Verification

**Parity against the Python reference** (`use_accel=False` forces the reference path, retained precisely so it stays testable):

| Quantity | Max difference |
|---|---|
| cost | 3.3e-12 |
| tau | 1.7e-6 |
| states | 1.2e-6 |
| controls | 3.2e-6 |

**Physics checks on the native trajectory** — exact endpoints, `cost == tau + control effort` (1.5e-5), and ODE residual `xdot - (Ax + Bu)` of 7.7e-6.

**Batched-cost correctness** — the grid scan can never beat the refined optimum, so tests assert it is both an upper bound and within 5% of the pairwise refined cost. The refined `connect` still determines every edge cost actually stored in the tree, so the algorithm is unchanged; batching only affects candidate filtering/ranking. The 2D example produces a bit-identical solution cost (15.688) and node count.

**Fallbacks** — a test drives the planner with a `Dynamics` implementation exposing only the protocol methods (no batch helpers), covering the path that `TorchDynamics` uses.

Tests: **26 passing, 1 skipped** (Torch, when PyTorch isn't installed), suite runtime 6.5s → 1.6s.

## Performance

`examples/double_integrator_2d.toml`, identical solution cost:

| Stage | Wall time |
|-------|-----------|
| Pure Python (before #4's Rust core) | ~24s |
| Rust cost + Python reconstruction (#4) | ~15s |
| Rust reconstruction (this PR, step 1) | ~10s |
| Rust batched cost + reconstruction (this PR) | **~1.5s** |

The 3D example (`double_integrator_3d.toml`, 400 nodes, 6-D state) plans in ~2.4s; I confirmed its solution is genuinely collision-free (0.59 clearance vs 0.3 robot radius, re-checked at 10x sample density) rather than relying on the isometric render, which projects start, goal, and obstacle onto nearly the same screen point.

## Notes

- No API breaks. `linear_cost`/`linear_connect` free functions are retained; `AnalyticLinearDynamics` gains a `use_accel` flag and `cost_batch_to`/`cost_batch_from`.
- Remaining follow-on: richer geometry (meshes, oriented boxes, capsules), moving collision checking into Rust, and connection-radius schedule tuning.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2975-5a12-770d-9d09-6ed32a7e8d42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2975-5a12-770d-9d09-6ed32a7e8d42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

