### PR TITLE
feat(viz): keep live window open in foreground, report run duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ See [`docs/rewrite-plan.md`](docs/rewrite-plan.md) for the design and
   self-describing bundle.
 - **Visualization** — 3D rendering of the tree, trajectories, robot, and
   obstacles, with optional live updates during tree growth (headless supported).
+  The window opens in the foreground and stays open after planning finishes so
+  the result can be inspected; press `q` (or close the window) to exit. Set
+  `[visualization] keep_open = false` (or pass `--no-keep-open`) for unattended
+  runs.
+- **Timing** — planning duration and throughput are reported and stored in the
+  saved experiment metadata.
 - **Rust hot path (optional)** — a `krrtstar_core` extension runs the whole
   connection in native code: the Euclidean neighbor pre-filter, batched
   connection costs (sharing a precomputed time grid), and full trajectory
@@ -47,6 +53,21 @@ poetry run maturin develop --manifest-path rust/Cargo.toml --release
 
 ```bash
 poetry run python -m krrtstar.cli examples/double_integrator_2d.toml --out /tmp/exp
+```
+
+Watch the tree grow in 3D and inspect the result when it finishes:
+
+```bash
+poetry run python -m krrtstar.cli examples/double_integrator_2d.toml --live
+```
+
+which reports, for example:
+
+```
+[krrtstar] backend=rust dynamics=linear x_dim=4 target_nodes=300
+[krrtstar] nodes=236 found=True cost=15.6876
+[krrtstar] planning time: 1.42 s (166.2 nodes/s)
+[krrtstar] total time: 1.51 s
 ```
 
 Or from Python:

--- a/examples/double_integrator_2d.toml
+++ b/examples/double_integrator_2d.toml
@@ -48,3 +48,5 @@ live = false
 show_tree = true
 show_robot = true
 show_obstacles = true
+# Hold the window open after planning so the result can be inspected.
+keep_open = true

--- a/krrtstar/cli.py
+++ b/krrtstar/cli.py
@@ -8,11 +8,25 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
+from typing import Optional
 
+from .accel import backend
 from .config import load_config
 from .experiment import save_experiment
 from .run import run_experiment
-from .accel import backend
+
+
+def format_duration(seconds: Optional[float]) -> str:
+    """Human-readable duration, e.g. ``842.1 ms``, ``1.47 s``, ``2m 03.4s``."""
+    if seconds is None:
+        return "n/a"
+    if seconds < 1.0:
+        return f"{seconds * 1000.0:.1f} ms"
+    if seconds < 60.0:
+        return f"{seconds:.2f} s"
+    minutes, rest = divmod(seconds, 60.0)
+    return f"{int(minutes)}m {rest:04.1f}s"
 
 
 def main(argv=None) -> int:
@@ -22,18 +36,35 @@ def main(argv=None) -> int:
     parser.add_argument("--live", action="store_true", help="visualize tree growth live")
     parser.add_argument("--render", help="render the final result to an image path")
     parser.add_argument("--nodes", type=int, help="override planner.target_nodes")
+    parser.add_argument(
+        "--no-keep-open",
+        action="store_true",
+        help="close the live window when planning finishes instead of holding it open",
+    )
     args = parser.parse_args(argv)
 
     cfg = load_config(args.config)
     if args.live:
         cfg.visualization.live = True
+    if args.no_keep_open:
+        cfg.visualization.keep_open = False
     if args.nodes is not None:
         cfg.planner.target_nodes = args.nodes
 
     print(f"[krrtstar] backend={backend()} dynamics={cfg.dynamics.kind} "
           f"x_dim={cfg.dynamics.x_dim} target_nodes={cfg.planner.target_nodes}")
+
+    wall_start = time.perf_counter()
     result = run_experiment(cfg)
-    print(f"[krrtstar] nodes={len(result.tree.nodes)} found={result.found} cost={result.cost}")
+
+    cost = "n/a" if result.cost is None else f"{result.cost:.4f}"
+    print(f"[krrtstar] nodes={len(result.tree.nodes)} found={result.found} cost={cost}")
+
+    rate = result.nodes_per_second
+    planning = f"[krrtstar] planning time: {format_duration(result.elapsed)}"
+    if rate is not None:
+        planning += f" ({rate:.1f} nodes/s)"
+    print(planning)
 
     if args.out:
         save_experiment(args.out, result, config_path=args.config)
@@ -47,6 +78,10 @@ def main(argv=None) -> int:
             print(f"[krrtstar] rendered to {args.render}")
         except Exception as exc:  # pragma: no cover - viz is optional
             print(f"[krrtstar] render skipped: {exc}", file=sys.stderr)
+
+    # Total wall time. With live visualization this includes however long the
+    # window stayed open for inspection.
+    print(f"[krrtstar] total time: {format_duration(time.perf_counter() - wall_start)}")
 
     return 0 if result.found else 1
 

--- a/krrtstar/config.py
+++ b/krrtstar/config.py
@@ -58,6 +58,9 @@ class VisualizationConfig:
     show_nodes: bool = False
     show_robot: bool = True
     show_obstacles: bool = True
+    # Hold the window open after planning finishes so the result can be
+    # inspected; disable for unattended runs.
+    keep_open: bool = True
 
 
 @dataclass
@@ -143,6 +146,7 @@ def _parse_visualization(data: Dict[str, Any]) -> VisualizationConfig:
         show_nodes=bool(data.get("show_nodes", False)),
         show_robot=bool(data.get("show_robot", True)),
         show_obstacles=bool(data.get("show_obstacles", True)),
+        keep_open=bool(data.get("keep_open", True)),
     )
 
 

--- a/krrtstar/experiment.py
+++ b/krrtstar/experiment.py
@@ -69,6 +69,8 @@ def save_experiment(
         "goal_index": result.goal_index,
         "solution_cost": result.cost,
         "found": result.found,
+        "elapsed_seconds": result.elapsed,
+        "iterations": result.iterations,
         "config": os.path.basename(config_path) if config_path else None,
     }
     if meta_extra:

--- a/krrtstar/planner.py
+++ b/krrtstar/planner.py
@@ -9,6 +9,7 @@ Euclidean nearest-neighbor pre-filter.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional
 
@@ -60,10 +61,18 @@ class PlanResult:
     goal_index: Optional[int]
     solution: Optional[List[Trajectory]]
     cost: Optional[float]
+    elapsed: Optional[float] = None
+    iterations: Optional[int] = None
 
     @property
     def found(self) -> bool:
         return self.goal_index is not None
+
+    @property
+    def nodes_per_second(self) -> Optional[float]:
+        if not self.elapsed:
+            return None
+        return len(self.tree.nodes) / self.elapsed
 
 
 class UniformSampler:
@@ -107,6 +116,8 @@ class KRRTStar:
         self.tree.add(Node(self.x_init, parent=-1, cost_from_start=0.0))
         self.goal_index: Optional[int] = None
         self._sampler = UniformSampler(self.state_bounds, self.rng)
+        self.elapsed: Optional[float] = None
+        self.iterations: Optional[int] = None
 
     # ------------------------------------------------------------------ #
     def _sample(self) -> np.ndarray:
@@ -224,6 +235,7 @@ class KRRTStar:
         progress_cb: Optional[ProgressCallback] = None,
         progress_every: int = 50,
     ) -> PlanResult:
+        started = time.perf_counter()
         for it in range(n):
             x_new = self._sample()
             parent = self._choose_parent(x_new)
@@ -239,12 +251,20 @@ class KRRTStar:
                 progress_cb(it, self.tree)
         if progress_cb is not None:
             progress_cb(n, self.tree)
+        self.elapsed = time.perf_counter() - started
+        self.iterations = n
         return self.result()
 
     def result(self) -> PlanResult:
         if self.goal_index is None:
-            return PlanResult(self.tree, None, None, None)
+            return PlanResult(
+                self.tree, None, None, None,
+                elapsed=self.elapsed, iterations=self.iterations,
+            )
         path = self.tree.path_to(self.goal_index)
         trajs = [self.tree.nodes[i].traj_from_parent for i in path if self.tree.nodes[i].traj_from_parent]
         cost = self.tree.nodes[self.goal_index].cost_from_start
-        return PlanResult(self.tree, self.goal_index, trajs, cost)
+        return PlanResult(
+            self.tree, self.goal_index, trajs, cost,
+            elapsed=self.elapsed, iterations=self.iterations,
+        )

--- a/krrtstar/run.py
+++ b/krrtstar/run.py
@@ -61,7 +61,11 @@ def _state_bounds(cfg: ExperimentConfig) -> np.ndarray:
 
 
 def run_experiment(cfg: ExperimentConfig, live_callback=None) -> PlanResult:
-    """Build and grow a planner from a config, optionally visualizing live."""
+    """Build and grow a planner from a config, optionally visualizing live.
+
+    When live visualization is enabled the viewer is finalized after growth so
+    the solution is drawn and the window stays open for inspection.
+    """
     planner = build_planner(cfg)
     progress_cb = None
     if cfg.visualization.live:
@@ -70,8 +74,16 @@ def run_experiment(cfg: ExperimentConfig, live_callback=None) -> PlanResult:
         else:
             from .viz import make_live_callback
 
-            progress_cb = make_live_callback(cfg)
-    return planner.grow(cfg.planner.target_nodes, progress_cb=progress_cb)
+            progress_cb = make_live_callback(
+                cfg, keep_open=cfg.visualization.keep_open
+            )
+    result = planner.grow(cfg.planner.target_nodes, progress_cb=progress_cb)
+
+    # Viewers expose finish() to draw the solution and hold the window open.
+    finish = getattr(progress_cb, "finish", None)
+    if callable(finish):
+        finish(result)
+    return result
 
 
 def run_from_file(path: str, live_callback=None) -> PlanResult:

--- a/krrtstar/viz.py
+++ b/krrtstar/viz.py
@@ -9,6 +9,10 @@ installs.
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 from typing import Any, Callable, List, Optional
 
 import numpy as np
@@ -145,6 +149,7 @@ def render_result(cfg, result, save_path=None, offscreen=False, show=None):
     """
     pyvista = _require_pyvista()
 
+    offscreen = _resolve_offscreen(pyvista, offscreen)
     plotter = pyvista.Plotter(off_screen=offscreen)
 
     if cfg.visualization.show_obstacles:
@@ -175,60 +180,267 @@ def render_result(cfg, result, save_path=None, offscreen=False, show=None):
 
     if show is None:
         show = not offscreen and save_path is None
-    if show:
-        plotter.show()
+    if show and not offscreen:
+        # Raise the window, then block so it stays up for inspection.
+        _bring_to_front(plotter, WINDOW_TITLE)
+        plotter.show(title=WINDOW_TITLE, auto_close=False)
 
     return plotter
 
 
 # --------------------------------------------------------------------------- #
+# Window placement
+# --------------------------------------------------------------------------- #
+WINDOW_TITLE = "krrtstar"
+
+
+def _bring_to_front(plotter, title: Optional[str] = None) -> None:
+    """Best-effort raise of the render window above others, with focus.
+
+    VTK exposes no portable "raise window" API, so this tries several
+    mechanisms in order and ignores every failure:
+
+    1. Make sure the window is mapped and drawn (sufficient on some platforms).
+    2. Qt-backed plotters (``pyvistaqt``) expose a real application window.
+    3. Windows: ``SetForegroundWindow`` on the native handle via ctypes.
+    4. macOS: ask System Events to front the current process.
+    5. X11: ask the window manager through ``wmctrl`` / ``xdotool``.
+    """
+    ren_win = getattr(plotter, "ren_win", None)
+    if ren_win is None:
+        return
+
+    try:
+        if title:
+            ren_win.SetWindowName(title)
+        ren_win.ShowWindowOn()
+        ren_win.Render()
+        ren_win.Frame()
+    except Exception:  # pragma: no cover - platform dependent
+        pass
+
+    app_window = getattr(plotter, "app_window", None)
+    if app_window is not None:  # pragma: no cover - requires pyvistaqt
+        for method in ("show", "raise_", "activateWindow"):
+            try:
+                getattr(app_window, method)()
+            except Exception:
+                pass
+        return
+
+    if sys.platform.startswith("win"):  # pragma: no cover - platform specific
+        try:
+            import ctypes
+
+            hwnd = int(ren_win.GetGenericWindowId())
+            ctypes.windll.user32.BringWindowToTop(hwnd)
+            ctypes.windll.user32.SetForegroundWindow(hwnd)
+        except Exception:
+            pass
+        return
+
+    if sys.platform == "darwin":  # pragma: no cover - platform specific
+        script = (
+            "tell application \"System Events\" to set frontmost of the first "
+            f"process whose unix id is {os.getpid()} to true"
+        )
+        _run_quiet(["osascript", "-e", script])
+        return
+
+    # X11 (also covers XWayland).
+    if title:  # pragma: no cover - needs a window manager
+        if _run_quiet(["wmctrl", "-a", title]):
+            return
+        _run_quiet(["xdotool", "search", "--name", title, "windowactivate"])
+
+
+def _run_quiet(cmd) -> bool:
+    """Run ``cmd`` if available; return True on a zero exit status."""
+    exe = shutil.which(cmd[0])
+    if exe is None:
+        return False
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed, non-shell argv
+            [exe, *cmd[1:]], capture_output=True, timeout=3, check=False
+        )
+    except Exception:  # pragma: no cover - platform dependent
+        return False
+    return completed.returncode == 0
+
+
+def has_display() -> bool:
+    """Whether an interactive display is likely available.
+
+    Used to avoid blocking on a window that can never appear (headless servers,
+    CI, SSH without X forwarding), which would otherwise hang the process.
+    """
+    if sys.platform.startswith("win") or sys.platform == "darwin":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _resolve_offscreen(pyvista, requested: bool) -> bool:
+    """Decide whether rendering must be offscreen.
+
+    Honours an explicit request, PyVista's global ``OFF_SCREEN`` switch (set by
+    the ``PYVISTA_OFF_SCREEN`` environment variable), and the absence of a
+    display. Keeping this in sync with the plotter matters: constructing an
+    on-screen plotter where no window can appear makes an interactive ``show()``
+    block forever.
+    """
+    if requested:
+        return True
+    if bool(getattr(pyvista, "OFF_SCREEN", False)):
+        return True
+    return not has_display()
+
+
+# --------------------------------------------------------------------------- #
 # Live rendering
 # --------------------------------------------------------------------------- #
-def make_live_callback(cfg, offscreen: bool = False) -> Callable[[int, Any], None]:
-    """Return a ``callback(iteration, tree)`` that live-renders tree growth.
+class LiveViewer:
+    """Live 3D view of tree growth that stays open for inspection.
 
-    The callback keeps a single persistent :class:`pyvista.Plotter` open across
-    invocations. Obstacles are drawn once; on every call the tree edges are
-    cleared and redrawn so the user watches the tree expand.
+    Instances are callable, so a viewer can be handed straight to
+    :meth:`krrtstar.planner.KRRTStar.grow` as its ``progress_cb``. A single
+    :class:`pyvista.Plotter` is kept across calls: obstacles are drawn once and
+    the tree edges are redrawn on each update.
 
-    Rendering is best-effort: any failure (including missing display, missing
-    PyVista, or a closed window) degrades to a no-op so the planner never
-    crashes because of visualization.
+    Call :meth:`finish` once planning completes to draw the solution and (unless
+    ``keep_open`` is False or rendering is offscreen) block so the window stays
+    up until the user closes it.
+
+    Rendering is best-effort: any failure (missing display, missing PyVista, a
+    closed window) disables the viewer rather than breaking the planner.
     """
-    state: dict = {"plotter": None, "failed": False, "tree_actors": []}
 
-    def _init_plotter():
+    def __init__(self, cfg, offscreen: bool = False, keep_open: bool = True,
+                 title: str = WINDOW_TITLE) -> None:
+        self.cfg = cfg
+        self.offscreen = bool(offscreen)
+        self.keep_open = bool(keep_open)
+        self.title = title
+        self.failed = False
+        self.finished = False
+        self._pyvista = None
+        self._plotter = None
+        self._tree_actors: List[Any] = []
+        # Resolved once the plotter is built (see _resolve_offscreen).
+        self._offscreen_effective = bool(offscreen)
+
+    # -------------------------------------------------------------- #
+    @property
+    def plotter(self):
+        return self._plotter
+
+    def _init_plotter(self):
         pyvista = _require_pyvista()
-        plotter = pyvista.Plotter(off_screen=offscreen)
-        if cfg.visualization.show_obstacles:
-            _add_obstacles(pyvista, plotter, cfg)
+        self._offscreen_effective = _resolve_offscreen(pyvista, self.offscreen)
+        plotter = pyvista.Plotter(
+            off_screen=self._offscreen_effective, title=self.title
+        )
+        if self.cfg.visualization.show_obstacles:
+            _add_obstacles(pyvista, plotter, self.cfg)
         plotter.add_axes()
         try:
-            plotter.show(interactive_update=True, auto_close=False)
-        except TypeError:  # pragma: no cover - older/newer signature differences
+            plotter.view_isometric()
+        except Exception:  # pragma: no cover - camera setup is best-effort
+            pass
+        try:
+            plotter.show(
+                title=self.title, interactive_update=True, auto_close=False
+            )
+        except TypeError:  # pragma: no cover - signature differences
             plotter.show(auto_close=False)
-        state["pyvista"] = pyvista
+        self._pyvista = pyvista
+        if not self._offscreen_effective:
+            _bring_to_front(plotter, self.title)
         return plotter
 
-    def callback(iteration: int, tree) -> None:
-        if state["failed"]:
+    def __call__(self, iteration: int, tree) -> None:
+        """Redraw the growing tree (planner progress callback)."""
+        if self.failed or self.finished:
             return
         try:
-            if state["plotter"] is None:
-                state["plotter"] = _init_plotter()
-            pyvista = state["pyvista"]
-            plotter = state["plotter"]
-
-            for actor in state["tree_actors"]:
+            if self._plotter is None:
+                self._plotter = self._init_plotter()
+            plotter = self._plotter
+            for actor in self._tree_actors:
                 try:
                     plotter.remove_actor(actor, reset_camera=False)
                 except Exception:  # pragma: no cover - actor may already be gone
                     pass
-            state["tree_actors"] = _add_tree(pyvista, plotter, cfg, tree)
-
+            self._tree_actors = _add_tree(self._pyvista, plotter, self.cfg, tree)
             plotter.update()
         except Exception as exc:  # pragma: no cover - environment dependent
-            state["failed"] = True
+            self.failed = True
             print(f"[krrtstar.viz] live rendering disabled: {exc}")
 
-    return callback
+    # -------------------------------------------------------------- #
+    def finish(self, result=None) -> None:
+        """Draw the final solution and hold the window open for inspection."""
+        if self.failed or self._plotter is None or self.finished:
+            return
+        self.finished = True
+        plotter = self._plotter
+        try:
+            if result is not None:
+                solution = getattr(result, "solution", None)
+                if solution:
+                    _add_solution(self._pyvista, plotter, self.cfg, solution)
+                if self.cfg.visualization.show_robot:
+                    x_init = self.cfg.planner.x_init
+                    x_goal = self.cfg.planner.x_goal
+                    if x_init is not None:
+                        _add_robot(
+                            self._pyvista, plotter, self.cfg,
+                            np.asarray(x_init, float), "royalblue",
+                        )
+                    if x_goal is not None:
+                        _add_robot(
+                            self._pyvista, plotter, self.cfg,
+                            np.asarray(x_goal, float), "gold",
+                        )
+            # The initial camera only framed the obstacles; refit so the whole
+            # tree and solution are visible for inspection.
+            try:
+                plotter.reset_camera()
+            except Exception:  # pragma: no cover - camera setup is best-effort
+                pass
+            plotter.render()
+        except Exception as exc:  # pragma: no cover - environment dependent
+            print(f"[krrtstar.viz] could not draw final solution: {exc}")
+
+        # Offscreen rendering has no window to keep open, and blocking would
+        # hang automated/headless runs.
+        if self._offscreen_effective or not self.keep_open:
+            return
+
+        # VTK's interactor quits on 'q'/'e'; some window managers do not deliver
+        # a close event to it, so mention the key explicitly.
+        print("[krrtstar.viz] window open for inspection - press 'q' (or close it) to exit")
+        try:  # pragma: no cover - requires an interactive display
+            _bring_to_front(plotter, self.title)
+            plotter.show(title=self.title, auto_close=False)
+        except Exception:  # pragma: no cover - fall back to the raw event loop
+            try:
+                plotter.iren.start()
+            except Exception as exc:
+                print(f"[krrtstar.viz] could not hold the window open: {exc}")
+
+    def close(self) -> None:
+        """Close the window, if one is open."""
+        if self._plotter is None:
+            return
+        try:
+            self._plotter.close()
+        except Exception:  # pragma: no cover - already closed
+            pass
+        self._plotter = None
+
+
+def make_live_callback(
+    cfg, offscreen: bool = False, keep_open: bool = True
+) -> "LiveViewer":
+    """Return a :class:`LiveViewer` for live rendering of tree growth."""
+    return LiveViewer(cfg, offscreen=offscreen, keep_open=keep_open)

--- a/tests/test_timing_and_live.py
+++ b/tests/test_timing_and_live.py
@@ -1,0 +1,234 @@
+import json
+import os
+
+import numpy as np
+import pytest
+
+from krrtstar.cli import format_duration
+from krrtstar.dynamics.linear import AnalyticLinearDynamics
+from krrtstar.experiment import save_experiment
+from krrtstar.planner import KRRTStar
+
+EXAMPLE = os.path.join(os.path.dirname(__file__), "..", "examples", "double_integrator_2d.toml")
+
+
+def free_space_planner(seed=1, **kw):
+    dyn = AnalyticLinearDynamics(np.zeros((2, 2)), np.eye(2))
+    return KRRTStar(
+        dynamics=dyn,
+        state_bounds=np.array([[-4, -4], [4, 4]]),
+        x_init=np.array([-3.0, -3.0]),
+        x_goal=np.array([3.0, 3.0]),
+        connection_radius=8.0,
+        euclidean_gate=8.0,
+        seed=seed,
+        **kw,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Timing
+# --------------------------------------------------------------------------- #
+def test_result_reports_elapsed_and_rate():
+    result = free_space_planner().grow(40)
+    assert result.elapsed is not None
+    assert result.elapsed > 0.0
+    assert result.iterations == 40
+    rate = result.nodes_per_second
+    assert rate is not None and rate > 0.0
+    assert rate == pytest.approx(len(result.tree.nodes) / result.elapsed, rel=1e-6)
+
+
+def test_elapsed_excludes_nothing_obvious_and_grows_with_work():
+    small = free_space_planner(seed=2).grow(20)
+    large = free_space_planner(seed=2).grow(120)
+    assert large.elapsed > small.elapsed
+
+
+def test_elapsed_is_persisted_in_experiment_meta(tmp_path):
+    result = free_space_planner(seed=3).grow(30)
+    bundle = str(tmp_path / "exp")
+    save_experiment(bundle, result, config_path=EXAMPLE)
+    with open(os.path.join(bundle, "meta.json")) as fh:
+        meta = json.load(fh)
+    assert meta["elapsed_seconds"] == pytest.approx(result.elapsed)
+    assert meta["iterations"] == 30
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (None, "n/a"),
+        (0.0421, "42.1 ms"),
+        (1.4712, "1.47 s"),
+        (59.9, "59.90 s"),
+        (83.4, "1m 23.4s"),
+    ],
+)
+def test_format_duration(seconds, expected):
+    assert format_duration(seconds) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Live viewer lifecycle
+# --------------------------------------------------------------------------- #
+def test_live_viewer_is_a_usable_progress_callback():
+    """The viewer must be callable and degrade gracefully without PyVista."""
+    from krrtstar.viz import LiveViewer, make_live_callback
+
+    cfg = _example_cfg()
+    viewer = make_live_callback(cfg, offscreen=True, keep_open=False)
+    assert isinstance(viewer, LiveViewer)
+    assert callable(viewer)
+    assert hasattr(viewer, "finish")
+
+
+def test_run_experiment_finalizes_the_viewer():
+    """run_experiment must call finish() so the window shows the solution."""
+    from krrtstar.run import run_experiment
+
+    cfg = _example_cfg()
+    cfg.visualization.live = True
+    cfg.planner.target_nodes = 25
+
+    class RecordingViewer:
+        def __init__(self):
+            self.calls = 0
+            self.finished_with = "not-called"
+
+        def __call__(self, iteration, tree):
+            self.calls += 1
+
+        def finish(self, result=None):
+            self.finished_with = result
+
+    viewer = RecordingViewer()
+    result = run_experiment(cfg, live_callback=viewer)
+    assert viewer.calls >= 1
+    assert viewer.finished_with is result
+
+
+def test_finish_is_noop_without_a_plotter():
+    """finish() before any render must not raise (no window was opened)."""
+    from krrtstar.viz import LiveViewer
+
+    viewer = LiveViewer(_example_cfg(), offscreen=True, keep_open=False)
+    viewer.finish(None)  # should be a quiet no-op
+    viewer.close()
+
+
+def test_keep_open_defaults_true_and_is_configurable():
+    from krrtstar.config import parse_config
+
+    cfg = parse_config({"dynamics": {"x_dim": 2, "u_dim": 2},
+                        "environment": {"bounds": [[-1, -1, -1], [1, 1, 1]]}})
+    assert cfg.visualization.keep_open is True
+
+    cfg2 = parse_config({"dynamics": {"x_dim": 2, "u_dim": 2},
+                         "environment": {"bounds": [[-1, -1, -1], [1, 1, 1]]},
+                         "visualization": {"keep_open": False}})
+    assert cfg2.visualization.keep_open is False
+
+
+def test_offscreen_finish_does_not_block():
+    """Offscreen finish must return promptly (guards against a hung CI run)."""
+    pytest.importorskip("pyvista")
+    import time
+
+    from krrtstar.run import build_planner
+    from krrtstar.viz import LiveViewer
+
+    cfg = _example_cfg()
+    cfg.planner.target_nodes = 20
+    viewer = LiveViewer(cfg, offscreen=True, keep_open=True)
+    planner = build_planner(cfg)
+    try:
+        result = planner.grow(20, progress_cb=viewer, progress_every=10)
+        start = time.perf_counter()
+        viewer.finish(result)
+        assert time.perf_counter() - start < 30.0
+    except Exception as exc:  # pragma: no cover - headless rendering may fail
+        if _is_headless_failure(exc):
+            pytest.skip(f"headless rendering unavailable: {exc}")
+        raise
+    finally:
+        viewer.close()
+
+
+# --------------------------------------------------------------------------- #
+# Offscreen resolution (guards against blocking on a window that cannot appear)
+# --------------------------------------------------------------------------- #
+def test_has_display_follows_environment(monkeypatch):
+    from krrtstar import viz
+
+    monkeypatch.setattr(viz.sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    assert viz.has_display() is False
+
+    monkeypatch.setenv("DISPLAY", ":0")
+    assert viz.has_display() is True
+
+
+def test_resolve_offscreen_prevents_blocking_without_a_display(monkeypatch):
+    """A headless run must resolve to offscreen so finish() cannot block."""
+    from krrtstar import viz
+
+    class FakePyvista:
+        OFF_SCREEN = False
+
+    # Explicit request wins.
+    assert viz._resolve_offscreen(FakePyvista, True) is True
+
+    # PyVista's global switch (PYVISTA_OFF_SCREEN) wins.
+    class GlobalOffscreen:
+        OFF_SCREEN = True
+
+    assert viz._resolve_offscreen(GlobalOffscreen, False) is True
+
+    # No display -> offscreen.
+    monkeypatch.setattr(viz, "has_display", lambda: False)
+    assert viz._resolve_offscreen(FakePyvista, False) is True
+
+    # Display available and nothing forcing offscreen -> interactive.
+    monkeypatch.setattr(viz, "has_display", lambda: True)
+    assert viz._resolve_offscreen(FakePyvista, False) is False
+
+
+def test_finish_does_not_block_when_resolved_offscreen(monkeypatch):
+    """finish() must respect the resolved offscreen flag, not the request."""
+    from krrtstar.viz import LiveViewer
+
+    viewer = LiveViewer(_example_cfg(), offscreen=False, keep_open=True)
+
+    calls = {"show": 0, "render": 0, "reset": 0}
+
+    class FakePlotter:
+        def render(self):
+            calls["render"] += 1
+
+        def reset_camera(self):
+            calls["reset"] += 1
+
+        def show(self, *a, **kw):  # must never be called for offscreen
+            calls["show"] += 1
+
+    viewer._plotter = FakePlotter()
+    viewer._pyvista = object()
+    viewer._offscreen_effective = True  # as resolved in a headless run
+
+    viewer.finish(None)
+    assert calls["show"] == 0
+    assert calls["render"] == 1
+
+
+def _example_cfg():
+    from krrtstar.config import load_config
+
+    return load_config(EXAMPLE)
+
+
+def _is_headless_failure(exc: Exception) -> bool:
+    hints = ("opengl", "osmesa", "glx", "egl", "display", "framebuffer", "x11")
+    text = str(exc).lower()
+    return any(h in text for h in hints)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The three UI changes requested, ahead of the remaining PR-notes work (richer geometry, collision checking in Rust, connection-radius tuning).

1. **The live window stays open** after planning completes so the result can be inspected, instead of disappearing when the process exits.
2. **The window opens in the foreground**, focused.
3. **Run duration is reported.**

[Live window held open in the foreground showing the solution](https://cursor.com/agents/bc-019f2975-5a12-770d-9d09-6ed32a7e8d42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flive_window_kept_open.png)

*Live window held open after planning: start (blue), goal (gold), wall obstacle (red), kinodynamic tree (light blue), and the solution (green).*

## 1. Window stays open

`make_live_callback`'s closure is replaced by a `LiveViewer` class (still callable, so it drops straight into `grow(progress_cb=...)`). It gains `finish()`, which the driver calls after growth to draw the final solution, refit the camera, and block until the user quits.

The camera previously framed only the obstacles, because `view_isometric()` ran at init before any tree existed — the goal ended up off-screen. `finish()` now calls `reset_camera()` so the whole scene is framed.

## 2. Foreground

VTK exposes **no portable raise/focus API** (I checked the render window: `SetWindowName`, `SetPosition`, `ShowWindowOn` exist; nothing for raising). So the window is given a title and then raised best-effort, trying in order: mapping and re-rendering, a Qt `app_window` (pyvistaqt), Win32 `SetForegroundWindow` via the native handle, macOS System Events, and X11 `wmctrl`/`xdotool`. Every step is optional and failures are ignored.

## 3. Timing

`PlanResult` gains `elapsed` and `iterations` plus a `nodes_per_second` property; `grow()` measures the run. The CLI reports planning time with throughput and total wall time, and `elapsed_seconds`/`iterations` are persisted in the experiment metadata:

```
[krrtstar] nodes=236 found=True cost=15.6876
[krrtstar] planning time: 1.42 s (166.2 nodes/s)
[krrtstar] total time: 1.51 s
```

## Bug found and fixed along the way

A headless `--live` run **hung indefinitely** (I hit it in testing: killed at the 180s timeout). The viewer's `offscreen` flag was out of sync with PyVista's global `OFF_SCREEN`, so it built an on-screen plotter where no window could appear and `show()` blocked forever. Offscreen is now resolved from the explicit request, PyVista's global switch, and the presence of a display, and `finish()` keys off that resolved value. A unit test asserts `finish()` never calls `show()` when resolved offscreen, so this can't regress and hang CI.

## Verification on a real display

This VM has an X display, so I verified the actual window rather than only the code paths:

- `xdotool` reports a window named `krrtstar` that is the **active** window with `_NET_WM_STATE_FOCUSED` → foreground works.
- It **stays open** after planning; results print only after quitting.
- It **exits cleanly** on quit, then reports the timings.

One useful discovery: VTK's interactor quits on `q`/`e`, and `xdotool windowclose` (WM_DELETE_WINDOW) is not honored by it in this environment — my first "hang" reading was a bad test method, not a code bug. I confirmed this by probing four PyVista patterns, including a plain single blocking `show()`: all hang on `windowclose`, all exit cleanly on `q`. Because some window managers behave this way, the hold-open prompt now names the key:

```
[krrtstar.viz] window open for inspection - press 'q' (or close it) to exit
```

## Notes

- `keep_open` config option (default `true`) and a `--no-keep-open` CLI flag for unattended runs.
- Tests: **42 passing, 1 skipped** (Torch). New coverage for elapsed/rate, duration formatting, metadata persistence, viewer lifecycle, and the offscreen-resolution guard.
- With live rendering on, `elapsed` includes redraw overhead (each update rebuilds the tree actors), so throughput is lower than a headless run; `total time` additionally includes however long the window stayed open.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2975-5a12-770d-9d09-6ed32a7e8d42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2975-5a12-770d-9d09-6ed32a7e8d42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

