### PR TITLE
feat(geometry): richer shapes + native parry3d collision checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -231,6 +231,9 @@ krrtstar/krrtstar/stats_log.txt
 krrtstar/krrtstar/path_log.txt
 krrtstar/krrtstar/test_path.path
 *.rrt
+# Mesh assets are source data, not C/C++ object files (*.obj is ignored above).
+!examples/assets/*.obj
+
 # krrtstar build/dev artifacts
 .venv/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ See [`docs/rewrite-plan.md`](docs/rewrite-plan.md) for the design and
   and control bounds in a TOML file. A single general optimal-time connection
   solver (controllability Gramian + arrival-time optimization) replaces the
   legacy per-model closed forms — no MATLAB/Maple.
-- **3D geometry & collision** — robot and obstacles as spheres/boxes; broad +
-  narrow phase collision checking; trajectory collision checking.
+- **3D geometry & collision** — spheres, oriented boxes, capsules, cylinders, and
+  triangle meshes loaded from `.obj` (or any format `trimesh`/`pyvista` can
+  read), for both the robot and the obstacles. Shapes can be rotated, and the
+  robot's orientation can be driven from the state (Euler indices or a
+  quaternion). Collision runs natively via `parry3d` when the Rust core is
+  built, with a pure-Python GJK narrow phase as the fallback; both are
+  cross-validated to agree exactly.
 - **kRRT\* planner** — nearest/near search, best-parent selection, and rewiring
   over the pluggable `Dynamics` interface.
 - **Save / load experiments** — persist the tree, config, and metadata as a
@@ -31,7 +36,8 @@ See [`docs/rewrite-plan.md`](docs/rewrite-plan.md) for the design and
 - **Rust hot path (optional)** — a `krrtstar_core` extension runs the whole
   connection in native code: the Euclidean neighbor pre-filter, batched
   connection costs (sharing a precomputed time grid), and full trajectory
-  reconstruction. The package falls back to pure Python when it is not built.
+  reconstruction, plus `parry3d` collision checking (~15x faster than the Python
+  fallback). The package falls back to pure Python when it is not built.
 - **Learned dynamics (best-effort)** — an optional PyTorch backend steers via
   gradient/shooting and is treated as best-effort.
 
@@ -85,6 +91,10 @@ poetry run pytest
 ```
 
 ## Layout
+
+> Mesh obstacles are treated as **surfaces**, not filled solids: a shape that
+> fits entirely inside a closed mesh without touching a triangle is not in
+> collision. Prefer primitives for large hollow volumes.
 
 ```
 krrtstar/        Python package (config, dynamics, geometry, planner, IO, viz)

--- a/docs/rewrite-plan.md
+++ b/docs/rewrite-plan.md
@@ -408,6 +408,25 @@ End-to-end on `examples/double_integrator_2d.toml` (identical solution cost):
 | Rust reconstruction | ~10s |
 | Rust batched cost + reconstruction | **~1.5s** |
 
-Follow-on work (not yet done): richer geometry (meshes, oriented boxes,
-capsules), moving collision checking into Rust, and asymptotic-optimality tuning
-of the connection-radius schedule.
+### Geometry and collision
+
+Richer geometry and native collision checking are implemented:
+
+* Shapes: sphere, box (axis-aligned or oriented), capsule, cylinder, and
+  triangle mesh loaded from `.obj` (or via `trimesh`/`pyvista`). Every shape may
+  carry its own rotation, and the robot's orientation can be driven from the
+  state through Euler indices or a quaternion.
+* Two interchangeable narrow phases, cross-validated to agree exactly: a
+  pure-Python GJK engine (`krrtstar/collision.py`, accurate to ~1e-15 on convex
+  cases) and a native `parry3d` scene in the Rust core (~15x faster: 1.9us vs
+  29.2us per query on the bundled rich-geometry scene).
+* Shapes are modelled as a convex *core* plus a *margin* (the round radius), so
+  a single support-function-based GJK path covers all convex pairs; meshes are
+  handled triangle-by-triangle with AABB pre-filtering.
+* Meshes are **surfaces**, not filled solids: a shape entirely inside a closed
+  mesh that touches no triangle is not in collision. Treating meshes as solids
+  (containment testing) remains open.
+
+Follow-on work (not yet done): asymptotic-optimality tuning of the
+connection-radius schedule, and optional solid (containment) semantics for
+meshes.

--- a/examples/assets/block.obj
+++ b/examples/assets/block.obj
@@ -1,0 +1,28 @@
+# A 2x2x2 cube centred at the origin, as a triangle mesh.
+# Used to demonstrate mesh obstacles loaded from file.
+v -1.0 -1.0 -1.0
+v  1.0 -1.0 -1.0
+v  1.0  1.0 -1.0
+v -1.0  1.0 -1.0
+v -1.0 -1.0  1.0
+v  1.0 -1.0  1.0
+v  1.0  1.0  1.0
+v -1.0  1.0  1.0
+# bottom (z = -1)
+f 1 3 2
+f 1 4 3
+# top (z = +1)
+f 5 6 7
+f 5 7 8
+# front (y = -1)
+f 1 2 6
+f 1 6 5
+# back (y = +1)
+f 4 3 7
+f 4 7 8
+# left (x = -1)
+f 1 5 8
+f 1 8 4
+# right (x = +1)
+f 2 3 7
+f 2 7 6

--- a/examples/rich_geometry_3d.toml
+++ b/examples/rich_geometry_3d.toml
@@ -1,0 +1,90 @@
+# 3D double integrator navigating an environment built from every supported
+# shape type: sphere, oriented box, capsule, cylinder, and a mesh loaded from
+# an OBJ file. The robot itself is a capsule.
+#
+#   state = [x, y, z, vx, vy, vz], control = [ax, ay, az]
+
+[dynamics]
+kind = "linear"
+x_dim = 6
+u_dim = 3
+A = [[0, 0, 0, 1, 0, 0],
+     [0, 0, 0, 0, 1, 0],
+     [0, 0, 0, 0, 0, 1],
+     [0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 0]]
+B = [[0, 0, 0],
+     [0, 0, 0],
+     [0, 0, 0],
+     [1, 0, 0],
+     [0, 1, 0],
+     [0, 0, 1]]
+R = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+u_bounds = [[-6, 6], [-6, 6], [-6, 6]]
+
+[planner]
+target_nodes = 600
+connection_radius = 16.0
+goal_bias = 0.1
+goal_tolerance = 1.0
+rewire = true
+euclidean_gate = 9.0
+seed = 5
+x_init = [-7, -7, 0, 0, 0, 0]
+x_goal = [7, 7, 0, 0, 0, 0]
+state_bounds = [[-8, -8, -4, -3, -3, -3], [8, 8, 4, 3, 3, 3]]
+
+# The robot is a capsule standing along its local Z axis.
+[robot]
+pose_from_state = { x = 0, y = 1, z = 2 }
+[[robot.geometry]]
+type = "capsule"
+center = [0, 0, 0]
+radius = 0.25
+height = 0.6
+
+[environment]
+bounds = [[-8, -8, -4], [8, 8, 4]]
+
+# A wall rotated 45 degrees about Z (rotation given as roll/pitch/yaw radians).
+[[environment.obstacles]]
+type = "box"
+center = [0, 0, 0]
+extents = [8.0, 0.8, 6.0]
+euler = [0.0, 0.0, 0.7853981633974483]
+
+# A round pillar.
+[[environment.obstacles]]
+type = "cylinder"
+center = [-4.0, 3.5, 0.0]
+radius = 1.0
+height = 6.0
+
+# A capsule laid along the X axis (rotate local Z onto X = pitch 90 degrees).
+[[environment.obstacles]]
+type = "capsule"
+center = [4.0, -3.0, 0.0]
+radius = 0.8
+height = 3.0
+euler = [0.0, 1.5707963267948966, 0.0]
+
+# A plain ball.
+[[environment.obstacles]]
+type = "sphere"
+center = [-3.0, -4.5, 1.0]
+radius = 1.2
+
+# A mesh obstacle loaded from an OBJ file (2x2x2 cube, scaled down).
+[[environment.obstacles]]
+type = "mesh"
+path = "assets/block.obj"
+center = [4.5, 4.0, 0.0]
+scale = 0.9
+euler = [0.0, 0.0, 0.3]
+
+[visualization]
+live = false
+show_robot = true
+show_obstacles = true
+keep_open = true

--- a/krrtstar/__init__.py
+++ b/krrtstar/__init__.py
@@ -12,11 +12,17 @@ from .dynamics.base import Dynamics, Trajectory
 from .dynamics.linear import AnalyticLinearDynamics
 from .geometry import (
     Box,
+    Capsule,
     CollisionChecker,
+    Cylinder,
     Environment,
+    Mesh,
     PoseMapping,
     Robot,
     Sphere,
+    load_mesh,
+    rotation_from_euler,
+    rotation_from_quat,
 )
 from .planner import KRRTStar, Node, PlanResult, Tree
 
@@ -26,11 +32,17 @@ __all__ = [
     "Trajectory",
     "AnalyticLinearDynamics",
     "Box",
+    "Capsule",
+    "Cylinder",
+    "Mesh",
     "Sphere",
     "Robot",
     "Environment",
     "PoseMapping",
     "CollisionChecker",
+    "load_mesh",
+    "rotation_from_euler",
+    "rotation_from_quat",
     "KRRTStar",
     "Tree",
     "Node",

--- a/krrtstar/accel.py
+++ b/krrtstar/accel.py
@@ -57,6 +57,55 @@ def linear_cost(
     )
 
 
+def _add_shape(scene, side: str, shape) -> None:
+    """Register one shape with the native scene (``side`` is robot/obstacle)."""
+    from .geometry import Box, Capsule, Cylinder, Mesh, Sphere
+
+    center = np.ascontiguousarray(shape.center, float)
+    if isinstance(shape, Sphere):
+        scene.add_sphere(side, center, float(shape.radius))
+        return
+    rot = np.ascontiguousarray(getattr(shape, "rotation", np.eye(3)), float).reshape(-1)
+    if isinstance(shape, Box):
+        scene.add_box(side, center, rot, np.ascontiguousarray(shape.extents, float))
+    elif isinstance(shape, Capsule):
+        scene.add_capsule(side, center, rot, float(shape.radius), float(shape.height))
+    elif isinstance(shape, Cylinder):
+        scene.add_cylinder(side, center, rot, float(shape.radius), float(shape.height))
+    elif isinstance(shape, Mesh):
+        scene.add_mesh(
+            side,
+            center,
+            rot,
+            np.ascontiguousarray(shape.vertices, float),
+            np.ascontiguousarray(shape.faces, np.uint32),
+            float(shape.scale),
+        )
+    else:
+        raise TypeError(f"Unsupported shape for the native scene: {type(shape)!r}")
+
+
+def make_collision_scene(robot, environment):
+    """Build a native collision scene, or return ``None`` if unavailable.
+
+    Robot shapes are registered in the robot frame; obstacles in world
+    coordinates. Queries supply the robot's world transform, so the state ->
+    pose mapping stays in Python (see :class:`krrtstar.geometry.PoseMapping`).
+    """
+    if not HAVE_RUST or not hasattr(_core, "CollisionScene"):
+        return None
+    try:
+        scene = _core.CollisionScene()
+        for shape in robot.shapes:
+            _add_shape(scene, "robot", shape)
+        for shape in environment.obstacles:
+            _add_shape(scene, "obstacle", shape)
+        scene.finalize()
+        return scene
+    except Exception:  # pragma: no cover - unsupported shape or older core
+        return None
+
+
 def make_connector(
     A: np.ndarray,
     B: np.ndarray,

--- a/krrtstar/collision.py
+++ b/krrtstar/collision.py
@@ -1,0 +1,443 @@
+"""Pure-Python narrow-phase collision engine (GJK distance).
+
+Every shape in :mod:`krrtstar.geometry` is modelled as a convex *core* set plus a
+scalar *margin* (its round radius). Two shapes intersect exactly when the
+distance between their cores is at most the sum of their margins, so a single
+GJK distance routine over support functions covers spheres, boxes (oriented or
+not), capsules, cylinders and triangles.
+
+Meshes are triangle soups and therefore not convex: they are handled by running
+GJK per triangle, with axis-aligned bounding box lower bounds used to prune
+triangles that cannot beat the best distance found so far.
+
+The public entry points are :func:`gjk_distance`, :func:`shapes_distance` and
+:func:`shapes_intersect`; :mod:`krrtstar.geometry` delegates its
+``shapes_collide`` to the latter.
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import Optional, Sequence, Tuple
+
+import numpy as np
+
+from .geometry import Mesh
+
+__all__ = [
+    "closest_point_on_segment",
+    "closest_point_on_triangle",
+    "closest_point_on_tetrahedron",
+    "gjk_distance",
+    "shapes_distance",
+    "shapes_intersect",
+]
+
+# Squared length below which a vector counts as the zero vector.
+_ZERO_SQ = 1e-24
+# Denominators below this are treated as degenerate (areas/volumes are squared
+# quantities, hence the fairly small value).
+_DEGENERATE = 1e-30
+# Slack that makes exact touching count as a collision.
+_TOUCH_EPS = 1e-9
+
+_INF = float("inf")
+_DEFAULT_DIRECTION = np.array([1.0, 0.0, 0.0])
+
+
+# --------------------------------------------------------------------------- #
+# Closest point on a simplex to the origin
+#
+# Each routine returns ``(closest_point, kept)`` where ``kept`` indexes the
+# vertices that actually support the closest point, which is what GJK needs in
+# order to shrink its simplex.
+# --------------------------------------------------------------------------- #
+def closest_point_on_segment(
+    a: np.ndarray, b: np.ndarray
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """Closest point of the segment ``ab`` to the origin."""
+    ab = b - a
+    denom = float(ab @ ab)
+    if denom <= _ZERO_SQ:
+        return a, (0,)
+    t = -float(a @ ab) / denom
+    if t <= 0.0:
+        return a, (0,)
+    if t >= 1.0:
+        return b, (1,)
+    return a + t * ab, (0, 1)
+
+
+def _closest_point_on_edges(
+    verts: Sequence[np.ndarray], edges: Sequence[Tuple[int, int]]
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """Best of several segments, used as the degenerate-simplex fallback."""
+    best_point = None
+    best_kept: Tuple[int, ...] = ()
+    best_sq = _INF
+    for i, j in edges:
+        point, kept = closest_point_on_segment(verts[i], verts[j])
+        sq = float(point @ point)
+        if sq < best_sq:
+            best_sq = sq
+            best_point = point
+            best_kept = (i,) if kept == (0,) else (j,) if kept == (1,) else (i, j)
+    return best_point, best_kept
+
+
+def closest_point_on_triangle(
+    a: np.ndarray, b: np.ndarray, c: np.ndarray
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """Closest point of triangle ``abc`` to the origin (Voronoi region test)."""
+    ab = b - a
+    ac = c - a
+
+    # Vertex region A.
+    d1 = -float(ab @ a)
+    d2 = -float(ac @ a)
+    if d1 <= 0.0 and d2 <= 0.0:
+        return a, (0,)
+
+    # Vertex region B.
+    d3 = -float(ab @ b)
+    d4 = -float(ac @ b)
+    if d3 >= 0.0 and d4 <= d3:
+        return b, (1,)
+
+    # Edge region AB.
+    vc = d1 * d4 - d3 * d2
+    if vc <= 0.0 and d1 >= 0.0 and d3 <= 0.0:
+        denom = d1 - d3
+        if denom > 0.0:
+            return a + (d1 / denom) * ab, (0, 1)
+
+    # Vertex region C.
+    d5 = -float(ab @ c)
+    d6 = -float(ac @ c)
+    if d6 >= 0.0 and d5 <= d6:
+        return c, (2,)
+
+    # Edge region AC.
+    vb = d5 * d2 - d1 * d6
+    if vb <= 0.0 and d2 >= 0.0 and d6 <= 0.0:
+        denom = d2 - d6
+        if denom > 0.0:
+            return a + (d2 / denom) * ac, (0, 2)
+
+    # Edge region BC.
+    va = d3 * d6 - d5 * d4
+    if va <= 0.0 and (d4 - d3) >= 0.0 and (d5 - d6) >= 0.0:
+        denom = (d4 - d3) + (d5 - d6)
+        if denom > 0.0:
+            return b + ((d4 - d3) / denom) * (c - b), (1, 2)
+
+    # Face region.
+    denom = va + vb + vc
+    if denom <= _DEGENERATE:
+        # Collinear or duplicated vertices: the Voronoi tests above can all
+        # fail, so fall back to the three edges.
+        return _closest_point_on_edges((a, b, c), ((0, 1), (0, 2), (1, 2)))
+    v = vb / denom
+    w = vc / denom
+    return a + v * ab + w * ac, (0, 1, 2)
+
+
+_TETRA_FACES = ((1, 2, 3), (0, 2, 3), (0, 1, 3), (0, 1, 2))
+
+
+def closest_point_on_tetrahedron(
+    a: np.ndarray, b: np.ndarray, c: np.ndarray, d: np.ndarray
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """Closest point of tetrahedron ``abcd`` to the origin.
+
+    Returns the origin itself (with all four vertices kept) when the origin is
+    contained in the tetrahedron.
+    """
+    verts = (a, b, c, d)
+    basis = np.empty((3, 3))
+    basis[:, 0] = b - a
+    basis[:, 1] = c - a
+    basis[:, 2] = d - a
+
+    faces = _TETRA_FACES
+    if abs(float(np.linalg.det(basis))) > _DEGENERATE:
+        try:
+            lam = np.linalg.solve(basis, -a)
+        except np.linalg.LinAlgError:  # pragma: no cover - guarded by det
+            lam = None
+        if lam is not None:
+            bary = (1.0 - float(lam.sum()), float(lam[0]), float(lam[1]), float(lam[2]))
+            outside = tuple(i for i, value in enumerate(bary) if value < 0.0)
+            if not outside:
+                return np.zeros(3), (0, 1, 2, 3)
+            faces = tuple(_TETRA_FACES[i] for i in outside)
+
+    best_point = None
+    best_kept: Tuple[int, ...] = ()
+    best_sq = _INF
+    for face in faces:
+        i, j, k = face
+        point, kept = closest_point_on_triangle(verts[i], verts[j], verts[k])
+        sq = float(point @ point)
+        if sq < best_sq:
+            best_sq = sq
+            best_point = point
+            best_kept = tuple(face[m] for m in kept)
+    return best_point, best_kept
+
+
+def _closest_point_on_simplex(
+    simplex: Sequence[np.ndarray],
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    n = len(simplex)
+    if n == 1:
+        return simplex[0], (0,)
+    if n == 2:
+        return closest_point_on_segment(simplex[0], simplex[1])
+    if n == 3:
+        return closest_point_on_triangle(simplex[0], simplex[1], simplex[2])
+    return closest_point_on_tetrahedron(simplex[0], simplex[1], simplex[2], simplex[3])
+
+
+# --------------------------------------------------------------------------- #
+# Convex wrapper for a single mesh triangle
+# --------------------------------------------------------------------------- #
+class _Triangle:
+    """Convex core of one triangle, exposing the shape protocol GJK needs."""
+
+    __slots__ = ("vertices", "_lo", "_hi")
+
+    margin = 0.0
+
+    def __init__(self, vertices: Optional[np.ndarray] = None) -> None:
+        self.vertices = None
+        self._lo = None
+        self._hi = None
+        if vertices is not None:
+            self.set_vertices(np.asarray(vertices, float).reshape(3, 3))
+
+    def set_vertices(
+        self, vertices: np.ndarray, lo: Optional[np.ndarray] = None, hi: Optional[np.ndarray] = None
+    ) -> "_Triangle":
+        """Point the wrapper at new vertices, optionally with a cached AABB."""
+        self.vertices = vertices
+        self._lo = lo
+        self._hi = hi
+        return self
+
+    @property
+    def center(self) -> np.ndarray:
+        return self.vertices.mean(axis=0)
+
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        return self.vertices[int(np.argmax(self.vertices @ direction))]
+
+    def core_points(self) -> np.ndarray:
+        return self.vertices
+
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        if self._lo is None:
+            return self.vertices.min(axis=0), self.vertices.max(axis=0)
+        return self._lo, self._hi
+
+
+# --------------------------------------------------------------------------- #
+# GJK
+# --------------------------------------------------------------------------- #
+def _initial_direction(shape_a, shape_b) -> np.ndarray:
+    """A direction pointing from ``shape_a`` towards ``shape_b``."""
+    ca = getattr(shape_a, "center", None)
+    cb = getattr(shape_b, "center", None)
+    if ca is not None and cb is not None:
+        d = np.asarray(cb, float) - np.asarray(ca, float)
+        if float(d @ d) > _ZERO_SQ:
+            return d
+    return _DEFAULT_DIRECTION
+
+
+def _gjk(shape_a, shape_b, max_iter: int, tol: float, cutoff: float) -> float:
+    """GJK distance between two convex cores.
+
+    ``cutoff`` allows an early exit: as soon as a certified lower bound exceeds
+    it, that lower bound is returned instead of the exact distance. Callers that
+    only need to compare against a threshold (or prune a running minimum) can
+    therefore skip the tail of the iteration.
+    """
+    support_a = shape_a.support
+    support_b = shape_b.support
+
+    d = _initial_direction(shape_a, shape_b)
+    simplex = [np.asarray(support_a(d), float) - np.asarray(support_b(-d), float)]
+    # Invariant maintained below: ``v`` is the closest point of ``simplex`` to
+    # the origin, so ``|v|`` is an upper bound on the distance.
+    v, _ = _closest_point_on_simplex(simplex)
+    # Support points already visited; revisiting one means the search has
+    # started to cycle on a degenerate simplex.
+    seen = {tuple(simplex[0].tolist())}
+
+    for _ in range(max_iter):
+        vv = float(v @ v)
+        if vv <= _ZERO_SQ:
+            return 0.0
+        d = -v
+        w = np.asarray(support_a(d), float) - np.asarray(support_b(-d), float)
+
+        vw = float(v @ w)
+        # The Minkowski difference lies in the half space ``x @ v >= vw``, so
+        # ``vw / |v|`` is a lower bound on the true distance while ``|v|`` is an
+        # upper bound.
+        if vv - vw <= tol * vv:
+            break
+        if vw > 0.0 and cutoff < _INF:
+            v_norm = sqrt(vv)
+            if vw > cutoff * v_norm:
+                return vw / v_norm
+        key = tuple(w.tolist())
+        if key in seen:
+            break
+        seen.add(key)
+
+        simplex.append(w)
+        v, kept = _closest_point_on_simplex(simplex)
+        if len(kept) == 4:  # origin enclosed by the simplex
+            return 0.0
+        if len(kept) != len(simplex):
+            simplex = [simplex[i] for i in kept]
+
+    return sqrt(float(v @ v))
+
+
+def gjk_distance(shape_a, shape_b, max_iter: int = 64, tol: float = 1e-9) -> float:
+    """Distance between the convex cores of two shapes, 0.0 if they intersect.
+
+    Only the shapes' ``support`` functions are used, so this works for any
+    convex core (spheres degenerate to a point, capsules to a segment).
+    """
+    return _gjk(shape_a, shape_b, max_iter, tol, _INF)
+
+
+# --------------------------------------------------------------------------- #
+# AABB helpers
+# --------------------------------------------------------------------------- #
+def _core_aabb(shape) -> Tuple[np.ndarray, np.ndarray]:
+    """World AABB of a shape's core (``shape.aabb()`` is margin-inflated)."""
+    lo, hi = shape.aabb()
+    margin = float(shape.margin)
+    if margin == 0.0:
+        return lo, hi
+    return lo + margin, hi - margin
+
+
+def _aabbs_overlap(alo, ahi, blo, bhi) -> bool:
+    return not (bool(np.any(ahi < blo)) or bool(np.any(bhi < alo)))
+
+
+def _aabb_gaps(lo, hi, blo, bhi) -> np.ndarray:
+    """Distance from each AABB in ``(lo, hi)`` (both ``(n, 3)``) to one AABB."""
+    gap = np.maximum(0.0, np.maximum(lo - bhi, blo - hi))
+    return np.sqrt(np.einsum("ij,ij->i", gap, gap))
+
+
+# --------------------------------------------------------------------------- #
+# Mesh (triangle soup) core distances
+# --------------------------------------------------------------------------- #
+def _triangle_shape_core_distance(mesh: Mesh, other, stop_below: float) -> float:
+    """Minimum core distance between a mesh's triangles and a convex core."""
+    best = _INF
+    tris = mesh.triangles()
+    if tris.shape[0] == 0:
+        return best
+    lo = tris.min(axis=1)
+    hi = tris.max(axis=1)
+    olo, ohi = _core_aabb(other)
+    bounds = _aabb_gaps(lo, hi, olo, ohi)
+
+    wrapper = _Triangle()
+    for i in np.argsort(bounds):
+        if bounds[i] >= best:
+            break
+        wrapper.set_vertices(tris[i], lo[i], hi[i])
+        dist = _gjk(wrapper, other, 64, 1e-9, best)
+        if dist < best:
+            best = dist
+            if best <= stop_below:
+                break
+    return best
+
+
+def _mesh_mesh_core_distance(mesh_a: Mesh, mesh_b: Mesh, stop_below: float) -> float:
+    """Minimum core distance between the triangles of two meshes."""
+    best = _INF
+    tris_a = mesh_a.triangles()
+    tris_b = mesh_b.triangles()
+    if tris_a.shape[0] == 0 or tris_b.shape[0] == 0:
+        return best
+    alo, ahi = tris_a.min(axis=1), tris_a.max(axis=1)
+    blo, bhi = tris_b.min(axis=1), tris_b.max(axis=1)
+
+    outer_bounds = _aabb_gaps(alo, ahi, blo.min(axis=0), bhi.max(axis=0))
+    wrap_a = _Triangle()
+    wrap_b = _Triangle()
+    for i in np.argsort(outer_bounds):
+        if outer_bounds[i] >= best:
+            break
+        inner_bounds = _aabb_gaps(blo, bhi, alo[i], ahi[i])
+        order = np.argsort(inner_bounds)
+        if inner_bounds[order[0]] >= best:
+            continue
+        wrap_a.set_vertices(tris_a[i], alo[i], ahi[i])
+        for j in order:
+            if inner_bounds[j] >= best:
+                break
+            wrap_b.set_vertices(tris_b[j], blo[j], bhi[j])
+            dist = _gjk(wrap_a, wrap_b, 64, 1e-9, best)
+            if dist < best:
+                best = dist
+                if best <= stop_below:
+                    return best
+    return best
+
+
+def _core_distance(a, b, stop_below: float = -_INF) -> float:
+    """Core-set distance, dispatching meshes to their per-triangle handling."""
+    a_mesh = isinstance(a, Mesh)
+    b_mesh = isinstance(b, Mesh)
+    if a_mesh and b_mesh:
+        return _mesh_mesh_core_distance(a, b, stop_below)
+    if a_mesh:
+        return _triangle_shape_core_distance(a, b, stop_below)
+    if b_mesh:
+        return _triangle_shape_core_distance(b, a, stop_below)
+    # A finite ``stop_below`` means the caller only needs a threshold test, so
+    # GJK may stop once its lower bound clears it.
+    return _gjk(a, b, 64, 1e-9, stop_below if stop_below > -_INF else _INF)
+
+
+# --------------------------------------------------------------------------- #
+# Public shape queries
+# --------------------------------------------------------------------------- #
+def shapes_distance(a, b) -> float:
+    """Distance between two shapes, 0.0 when they touch or overlap.
+
+    This is the core-set distance reduced by both margins, so a sphere is a
+    point core inflated by its radius and a capsule a segment core inflated by
+    its radius. A mesh with no faces has no geometry and is infinitely far away.
+    """
+    margins = float(a.margin) + float(b.margin)
+    core = _core_distance(a, b)
+    if core == _INF:  # empty mesh
+        return _INF
+    return max(0.0, core - margins)
+
+
+def shapes_intersect(a, b) -> bool:
+    """Narrow-phase intersection test; touching counts as intersecting."""
+    alo, ahi = a.aabb()
+    blo, bhi = b.aabb()
+    if not _aabbs_overlap(alo, ahi, blo, bhi):
+        return False
+
+    margins = float(a.margin) + float(b.margin)
+    threshold = margins + _TOUCH_EPS * (1.0 + margins)
+    core = _core_distance(a, b, stop_below=threshold)
+    return bool(core <= threshold)

--- a/krrtstar/config.py
+++ b/krrtstar/config.py
@@ -20,7 +20,20 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib  # type: ignore
 
 from .dynamics.linear import AnalyticLinearDynamics
-from .geometry import Box, CollisionChecker, Environment, PoseMapping, Robot, Sphere
+from .geometry import (
+    Box,
+    Capsule,
+    CollisionChecker,
+    Cylinder,
+    Environment,
+    Mesh,
+    PoseMapping,
+    Robot,
+    Sphere,
+    load_mesh,
+    rotation_from_euler,
+    rotation_from_quat,
+)
 
 
 @dataclass
@@ -98,30 +111,82 @@ def _parse_dynamics(data: Dict[str, Any]) -> DynamicsConfig:
     )
 
 
-def _parse_shape(data: Dict[str, Any]):
+def _parse_rotation(data: Dict[str, Any]):
+    """Read an optional orientation from a shape entry.
+
+    Accepts ``rotation`` as Euler angles ``[roll, pitch, yaw]``, a quaternion
+    ``[w, x, y, z]``, or a full 3x3 matrix; ``euler`` and ``quaternion`` are
+    accepted as explicit aliases.
+    """
+    if "euler" in data:
+        return rotation_from_euler(*[float(v) for v in data["euler"]])
+    if "quaternion" in data:
+        return rotation_from_quat([float(v) for v in data["quaternion"]])
+    if "rotation" in data:
+        return _arr(data["rotation"])  # geometry normalizes 3 / 4 / 3x3
+    return None
+
+
+def _parse_shape(data: Dict[str, Any], base_dir: str = "."):
     t = data["type"]
+    rotation = _parse_rotation(data)
     if t == "sphere":
-        center = _arr(data.get("center", [0, 0, 0]))
-        return Sphere(center=center, radius=float(data["radius"]))
+        return Sphere(center=_arr(data.get("center", [0, 0, 0])), radius=float(data["radius"]))
     if t == "box":
-        return Box(center=_arr(data["center"]), extents=_arr(data["extents"]))
+        return Box(center=_arr(data["center"]), extents=_arr(data["extents"]), rotation=rotation)
+    if t == "capsule":
+        return Capsule(
+            center=_arr(data.get("center", [0, 0, 0])),
+            radius=float(data["radius"]),
+            height=float(data["height"]),
+            rotation=rotation,
+        )
+    if t == "cylinder":
+        return Cylinder(
+            center=_arr(data.get("center", [0, 0, 0])),
+            radius=float(data["radius"]),
+            height=float(data["height"]),
+            rotation=rotation,
+        )
+    if t == "mesh":
+        path = data["path"]
+        if not os.path.isabs(path):
+            path = os.path.join(base_dir, path)
+        vertices, faces = load_mesh(path)
+        return Mesh(
+            vertices=vertices,
+            faces=faces,
+            center=_arr(data.get("center", [0, 0, 0])),
+            rotation=rotation,
+            scale=float(data.get("scale", 1.0)),
+        )
     raise ValueError(f"Unsupported shape type: {t}")
 
 
-def _parse_robot(data: Dict[str, Any]) -> Robot:
-    shapes = [_parse_shape(s) for s in data.get("geometry", [])]
-    pose_data = data.get("pose_from_state", {})
-    pose = PoseMapping(
-        x=int(pose_data.get("x", 0)),
-        y=int(pose_data.get("y", 1)),
-        z=None if pose_data.get("z") is None else int(pose_data["z"]),
+def _parse_pose_mapping(data: Dict[str, Any]) -> PoseMapping:
+    def idx(key):
+        return None if data.get(key) is None else int(data[key])
+
+    quat = data.get("quat")
+    return PoseMapping(
+        x=int(data.get("x", 0)),
+        y=int(data.get("y", 1)),
+        z=idx("z"),
+        roll=idx("roll"),
+        pitch=idx("pitch"),
+        yaw=idx("yaw"),
+        quat=None if quat is None else [int(v) for v in quat],
     )
-    return Robot(shapes=shapes, pose=pose)
 
 
-def _parse_environment(data: Dict[str, Any]) -> Environment:
+def _parse_robot(data: Dict[str, Any], base_dir: str = ".") -> Robot:
+    shapes = [_parse_shape(s, base_dir) for s in data.get("geometry", [])]
+    return Robot(shapes=shapes, pose=_parse_pose_mapping(data.get("pose_from_state", {})))
+
+
+def _parse_environment(data: Dict[str, Any], base_dir: str = ".") -> Environment:
     bounds = _arr(data["bounds"])
-    obstacles = [_parse_shape(s) for s in data.get("obstacles", [])]
+    obstacles = [_parse_shape(s, base_dir) for s in data.get("obstacles", [])]
     return Environment(bounds=bounds, obstacles=obstacles)
 
 
@@ -155,8 +220,10 @@ def parse_config(data: Dict[str, Any], base_dir: str = ".") -> ExperimentConfig:
         dynamics=_parse_dynamics(data.get("dynamics", {})),
         planner=_parse_planner(data.get("planner", {})),
         visualization=_parse_visualization(data.get("visualization", {})),
-        robot=_parse_robot(data.get("robot", {})),
-        environment=_parse_environment(data.get("environment", {"bounds": [[-10, -10, -10], [10, 10, 10]]})),
+        robot=_parse_robot(data.get("robot", {}), base_dir),
+        environment=_parse_environment(
+            data.get("environment", {"bounds": [[-10, -10, -10], [10, 10, 10]]}), base_dir
+        ),
         raw=data,
         base_dir=base_dir,
     )

--- a/krrtstar/geometry.py
+++ b/krrtstar/geometry.py
@@ -1,143 +1,563 @@
 """3D geometry primitives, robot model, and collision checking.
 
 Robot and obstacle geometry are described entirely by configuration data. The
-robot is a set of primitives defined in the robot frame; its world placement is
+robot is a set of shapes defined in the robot frame; its world placement is
 derived from the planner state through a configurable index mapping (which state
-components are x/y/z). This replaces Callisto's compiled robot/world model.
+components give position and, optionally, orientation). This replaces Callisto's
+compiled robot/world model.
+
+Supported shapes: :class:`Sphere`, :class:`Box` (axis-aligned or oriented),
+:class:`Capsule`, :class:`Cylinder`, and triangle :class:`Mesh`.
+
+Every shape exposes a *core* convex set plus a *margin* (its "round" radius):
+
+* sphere  -> core is a point,   margin = radius
+* capsule -> core is a segment, margin = radius
+* box     -> core is the (possibly oriented) box, margin = 0
+* cylinder-> core is the cylinder,                margin = 0
+* mesh    -> a soup of triangles (non-convex; handled per triangle), margin = 0
+
+Two shapes intersect when the distance between their cores is at most the sum of
+their margins. Cores are described by a support function, which is all the
+GJK-based narrow phase in :mod:`krrtstar.collision` (and parry3d in the Rust
+core) needs.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 
+# --------------------------------------------------------------------------- #
+# Rotations
+# --------------------------------------------------------------------------- #
+IDENTITY = np.eye(3)
 
+
+def rotation_from_euler(roll: float = 0.0, pitch: float = 0.0, yaw: float = 0.0) -> np.ndarray:
+    """Intrinsic Z-Y-X (yaw-pitch-roll) rotation matrix."""
+    cr, sr = np.cos(roll), np.sin(roll)
+    cp, sp = np.cos(pitch), np.sin(pitch)
+    cy, sy = np.cos(yaw), np.sin(yaw)
+    rx = np.array([[1, 0, 0], [0, cr, -sr], [0, sr, cr]], dtype=float)
+    ry = np.array([[cp, 0, sp], [0, 1, 0], [-sp, 0, cp]], dtype=float)
+    rz = np.array([[cy, -sy, 0], [sy, cy, 0], [0, 0, 1]], dtype=float)
+    return rz @ ry @ rx
+
+
+def rotation_from_quat(q: Sequence[float]) -> np.ndarray:
+    """Rotation matrix from a quaternion ``(w, x, y, z)`` (normalized)."""
+    w, x, y, z = (float(v) for v in q)
+    n = np.sqrt(w * w + x * x + y * y + z * z)
+    if n == 0.0:
+        return IDENTITY.copy()
+    w, x, y, z = w / n, x / n, y / n, z / n
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - w * z), 2 * (x * z + w * y)],
+            [2 * (x * y + w * z), 1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+            [2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=float,
+    )
+
+
+def _as_rotation(rotation) -> np.ndarray:
+    if rotation is None:
+        return IDENTITY.copy()
+    rotation = np.asarray(rotation, dtype=float)
+    if rotation.shape == (3, 3):
+        return rotation
+    if rotation.shape == (4,):
+        return rotation_from_quat(rotation)
+    if rotation.shape == (3,):  # roll, pitch, yaw
+        return rotation_from_euler(*rotation)
+    raise ValueError(f"Unsupported rotation specification with shape {rotation.shape}")
+
+
+def _vec3(value, default=0.0) -> np.ndarray:
+    if value is None:
+        return np.full(3, default, dtype=float)
+    arr = np.asarray(value, dtype=float).reshape(-1)
+    if arr.size != 3:
+        raise ValueError(f"Expected a 3-vector, got {arr.size} values")
+    return arr
+
+
+# --------------------------------------------------------------------------- #
+# Shapes
+# --------------------------------------------------------------------------- #
 @dataclass
 class Sphere:
-    center: np.ndarray  # (3,) in the owning frame
+    """A ball. Core set is its center point; the radius is the margin."""
+
+    center: np.ndarray
     radius: float
 
-    def translated(self, offset: np.ndarray) -> "Sphere":
-        return Sphere(np.asarray(self.center, float) + offset, self.radius)
+    def __post_init__(self):
+        self.center = _vec3(self.center)
+        self.radius = float(self.radius)
 
-    def aabb(self):
-        c = np.asarray(self.center, float)
-        r = self.radius
-        return c - r, c + r
+    @property
+    def margin(self) -> float:
+        return self.radius
+
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        return self.center
+
+    def core_points(self) -> np.ndarray:
+        return self.center.reshape(1, 3)
+
+    def transformed(self, rotation, translation) -> "Sphere":
+        rot = _as_rotation(rotation)
+        return Sphere(rot @ self.center + _vec3(translation), self.radius)
+
+    def translated(self, offset) -> "Sphere":
+        return Sphere(self.center + _vec3(offset), self.radius)
+
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        return self.center - self.radius, self.center + self.radius
 
 
 @dataclass
 class Box:
-    center: np.ndarray  # (3,)
-    extents: np.ndarray  # (3,) full side lengths
+    """A box, axis-aligned by default or oriented when ``rotation`` is given."""
 
-    def translated(self, offset: np.ndarray) -> "Box":
-        return Box(np.asarray(self.center, float) + offset, np.asarray(self.extents, float))
+    center: np.ndarray
+    extents: np.ndarray  # full side lengths
+    rotation: Optional[np.ndarray] = None
 
-    def aabb(self):
-        c = np.asarray(self.center, float)
-        h = np.asarray(self.extents, float) / 2.0
-        return c - h, c + h
+    def __post_init__(self):
+        self.center = _vec3(self.center)
+        self.extents = _vec3(self.extents)
+        self.rotation = _as_rotation(self.rotation)
 
+    @property
+    def margin(self) -> float:
+        return 0.0
 
-Shape = object  # Sphere | Box
+    @property
+    def half_extents(self) -> np.ndarray:
+        return self.extents / 2.0
 
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        # Farthest corner along `direction`: pick the sign of each local axis.
+        local = self.rotation.T @ np.asarray(direction, float)
+        signs = np.where(local >= 0.0, 1.0, -1.0)
+        return self.center + self.rotation @ (signs * self.half_extents)
 
-def _closest_point_on_box(point: np.ndarray, box: Box) -> np.ndarray:
-    lo, hi = box.aabb()
-    return np.minimum(np.maximum(point, lo), hi)
+    def core_points(self) -> np.ndarray:
+        h = self.half_extents
+        corners = np.array(
+            [[sx * h[0], sy * h[1], sz * h[2]]
+             for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)],
+            dtype=float,
+        )
+        return corners @ self.rotation.T + self.center
 
+    def transformed(self, rotation, translation) -> "Box":
+        rot = _as_rotation(rotation)
+        return Box(rot @ self.center + _vec3(translation), self.extents, rot @ self.rotation)
 
-def _sphere_box_collide(sphere: Sphere, box: Box) -> bool:
-    closest = _closest_point_on_box(np.asarray(sphere.center, float), box)
-    return float(np.linalg.norm(np.asarray(sphere.center, float) - closest)) <= sphere.radius
+    def translated(self, offset) -> "Box":
+        return Box(self.center + _vec3(offset), self.extents, self.rotation)
 
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        pts = self.core_points()
+        return pts.min(axis=0), pts.max(axis=0)
 
-def _sphere_sphere_collide(a: Sphere, b: Sphere) -> bool:
-    d = float(np.linalg.norm(np.asarray(a.center, float) - np.asarray(b.center, float)))
-    return d <= a.radius + b.radius
-
-
-def _box_box_collide(a: Box, b: Box) -> bool:
-    alo, ahi = a.aabb()
-    blo, bhi = b.aabb()
-    return bool(np.all(alo <= bhi) and np.all(blo <= ahi))
-
-
-def shapes_collide(a: Shape, b: Shape) -> bool:
-    """Narrow-phase collision test between two supported primitives."""
-    if isinstance(a, Sphere) and isinstance(b, Sphere):
-        return _sphere_sphere_collide(a, b)
-    if isinstance(a, Sphere) and isinstance(b, Box):
-        return _sphere_box_collide(a, b)
-    if isinstance(a, Box) and isinstance(b, Sphere):
-        return _sphere_box_collide(b, a)
-    if isinstance(a, Box) and isinstance(b, Box):
-        return _box_box_collide(a, b)
-    raise TypeError(f"Unsupported shape pair: {type(a)}, {type(b)}")
+    def is_axis_aligned(self, tol: float = 1e-12) -> bool:
+        return bool(np.allclose(self.rotation, IDENTITY, atol=tol))
 
 
 @dataclass
+class Capsule:
+    """A capsule: a segment along the local Z axis, inflated by ``radius``."""
+
+    center: np.ndarray
+    radius: float
+    height: float  # length of the inner segment (excludes the end caps)
+    rotation: Optional[np.ndarray] = None
+
+    def __post_init__(self):
+        self.center = _vec3(self.center)
+        self.radius = float(self.radius)
+        self.height = float(self.height)
+        self.rotation = _as_rotation(self.rotation)
+
+    @property
+    def margin(self) -> float:
+        return self.radius
+
+    def segment(self) -> Tuple[np.ndarray, np.ndarray]:
+        axis = self.rotation @ np.array([0.0, 0.0, self.height / 2.0])
+        return self.center - axis, self.center + axis
+
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        a, b = self.segment()
+        direction = np.asarray(direction, float)
+        return a if float(direction @ a) >= float(direction @ b) else b
+
+    def core_points(self) -> np.ndarray:
+        a, b = self.segment()
+        return np.stack([a, b])
+
+    def transformed(self, rotation, translation) -> "Capsule":
+        rot = _as_rotation(rotation)
+        return Capsule(
+            rot @ self.center + _vec3(translation), self.radius, self.height,
+            rot @ self.rotation,
+        )
+
+    def translated(self, offset) -> "Capsule":
+        return Capsule(self.center + _vec3(offset), self.radius, self.height, self.rotation)
+
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        pts = self.core_points()
+        return pts.min(axis=0) - self.radius, pts.max(axis=0) + self.radius
+
+
+@dataclass
+class Cylinder:
+    """A right circular cylinder whose axis is the local Z axis."""
+
+    center: np.ndarray
+    radius: float
+    height: float  # full height
+    rotation: Optional[np.ndarray] = None
+
+    def __post_init__(self):
+        self.center = _vec3(self.center)
+        self.radius = float(self.radius)
+        self.height = float(self.height)
+        self.rotation = _as_rotation(self.rotation)
+
+    @property
+    def margin(self) -> float:
+        return 0.0
+
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        # Exact cylinder support: extreme on the rim in the local XY plane and
+        # on the flat cap along local Z.
+        local = self.rotation.T @ np.asarray(direction, float)
+        radial = local[:2]
+        norm = float(np.linalg.norm(radial))
+        xy = (radial / norm) * self.radius if norm > 1e-15 else np.zeros(2)
+        z = (self.height / 2.0) if local[2] >= 0.0 else -(self.height / 2.0)
+        return self.center + self.rotation @ np.array([xy[0], xy[1], z])
+
+    def core_points(self) -> np.ndarray:
+        # Bounding sample: the two cap centers, used only for coarse bounds.
+        axis = self.rotation @ np.array([0.0, 0.0, self.height / 2.0])
+        return np.stack([self.center - axis, self.center + axis])
+
+    def transformed(self, rotation, translation) -> "Cylinder":
+        rot = _as_rotation(rotation)
+        return Cylinder(
+            rot @ self.center + _vec3(translation), self.radius, self.height,
+            rot @ self.rotation,
+        )
+
+    def translated(self, offset) -> "Cylinder":
+        return Cylinder(self.center + _vec3(offset), self.radius, self.height, self.rotation)
+
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        # Tight AABB of a cylinder: the axis extent plus the disc extent per axis.
+        axis = self.rotation @ np.array([0.0, 0.0, self.height / 2.0])
+        # Radial extent along world axis i is r * |sin(angle)| = r*sqrt(1 - u_i^2)
+        u = self.rotation @ np.array([0.0, 0.0, 1.0])
+        radial = self.radius * np.sqrt(np.maximum(0.0, 1.0 - u ** 2))
+        extent = np.abs(axis) + radial
+        return self.center - extent, self.center + extent
+
+
+@dataclass
+class Mesh:
+    """A triangle mesh (possibly non-convex).
+
+    ``vertices`` is ``(n, 3)`` and ``faces`` is ``(m, 3)`` of vertex indices.
+    Non-convex meshes are handled triangle-by-triangle by the narrow phase.
+
+    Semantics: a mesh is treated as a **surface**, not a filled solid. A shape
+    that fits entirely inside a closed mesh without touching any triangle is
+    therefore *not* in collision. Keep this in mind for large hollow meshes,
+    where a trajectory could pass through the interior: model such obstacles
+    with primitives (boxes/cylinders), or ensure the robot is large enough
+    relative to the mesh that it must touch a face.
+    """
+
+    vertices: np.ndarray
+    faces: np.ndarray
+    center: np.ndarray = field(default_factory=lambda: np.zeros(3))
+    rotation: Optional[np.ndarray] = None
+    scale: float = 1.0
+
+    def __post_init__(self):
+        self.vertices = np.asarray(self.vertices, dtype=float).reshape(-1, 3)
+        self.faces = np.asarray(self.faces, dtype=np.int64).reshape(-1, 3)
+        self.center = _vec3(self.center)
+        self.rotation = _as_rotation(self.rotation)
+        self.scale = float(self.scale)
+
+    @property
+    def margin(self) -> float:
+        return 0.0
+
+    def world_vertices(self) -> np.ndarray:
+        return (self.vertices * self.scale) @ self.rotation.T + self.center
+
+    def triangles(self) -> np.ndarray:
+        """World-frame triangles as an ``(m, 3, 3)`` array."""
+        return self.world_vertices()[self.faces]
+
+    def support(self, direction: np.ndarray) -> np.ndarray:
+        # Only meaningful for convex meshes; the narrow phase uses triangles().
+        verts = self.world_vertices()
+        return verts[int(np.argmax(verts @ np.asarray(direction, float)))]
+
+    def core_points(self) -> np.ndarray:
+        return self.world_vertices()
+
+    def transformed(self, rotation, translation) -> "Mesh":
+        rot = _as_rotation(rotation)
+        return Mesh(
+            self.vertices, self.faces, rot @ self.center + _vec3(translation),
+            rot @ self.rotation, self.scale,
+        )
+
+    def translated(self, offset) -> "Mesh":
+        return Mesh(self.vertices, self.faces, self.center + _vec3(offset),
+                    self.rotation, self.scale)
+
+    def aabb(self) -> Tuple[np.ndarray, np.ndarray]:
+        verts = self.world_vertices()
+        return verts.min(axis=0), verts.max(axis=0)
+
+
+Shape = object  # Sphere | Box | Capsule | Cylinder | Mesh
+
+PRIMITIVES = (Sphere, Box, Capsule, Cylinder, Mesh)
+
+
+# --------------------------------------------------------------------------- #
+# Mesh loading
+# --------------------------------------------------------------------------- #
+def load_obj(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Minimal OBJ reader returning ``(vertices, triangular_faces)``.
+
+    Polygonal faces are fan-triangulated. Vertex texture/normal indices
+    (``v/vt/vn``) are ignored.
+    """
+    vertices: List[List[float]] = []
+    faces: List[List[int]] = []
+    with open(path, "r") as fh:
+        for line in fh:
+            if line.startswith("v "):
+                parts = line.split()
+                vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
+            elif line.startswith("f "):
+                idx = []
+                for token in line.split()[1:]:
+                    raw = token.split("/")[0]
+                    i = int(raw)
+                    # OBJ indices are 1-based; negatives count from the end.
+                    idx.append(i - 1 if i > 0 else len(vertices) + i)
+                for k in range(1, len(idx) - 1):
+                    faces.append([idx[0], idx[k], idx[k + 1]])
+    if not vertices or not faces:
+        raise ValueError(f"No triangles found in OBJ file: {path}")
+    return np.asarray(vertices, dtype=float), np.asarray(faces, dtype=np.int64)
+
+
+def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Load a triangle mesh, returning ``(vertices, faces)``.
+
+    ``.obj`` is handled natively. Other formats are read through ``trimesh`` or
+    ``pyvista`` when either is installed.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".obj":
+        return load_obj(path)
+
+    try:
+        import trimesh  # noqa: WPS433 (optional dependency)
+
+        mesh = trimesh.load(path, force="mesh")
+        return (
+            np.asarray(mesh.vertices, dtype=float),
+            np.asarray(mesh.faces, dtype=np.int64),
+        )
+    except ImportError:
+        pass
+
+    try:
+        import pyvista  # noqa: WPS433 (optional dependency)
+
+        surface = pyvista.read(path).triangulate().extract_surface()
+        faces = surface.faces.reshape(-1, 4)[:, 1:]
+        return (
+            np.asarray(surface.points, dtype=float),
+            np.asarray(faces, dtype=np.int64),
+        )
+    except ImportError as exc:
+        raise ImportError(
+            f"Cannot load '{ext}' meshes; install trimesh or pyvista, "
+            "or supply an .obj file"
+        ) from exc
+
+
+# --------------------------------------------------------------------------- #
+# Pose mapping
+# --------------------------------------------------------------------------- #
+@dataclass
 class PoseMapping:
-    """Maps a planner state to a world-frame translation of the robot."""
+    """Maps a planner state to a world-frame rigid transform of the robot.
+
+    Position comes from the ``x``/``y``/``z`` state indices. Orientation is
+    optional: either Euler angles from the ``roll``/``pitch``/``yaw`` indices or
+    a quaternion from four ``quat`` indices (``w, x, y, z``).
+    """
 
     x: int = 0
     y: int = 1
     z: Optional[int] = None
+    roll: Optional[int] = None
+    pitch: Optional[int] = None
+    yaw: Optional[int] = None
+    quat: Optional[Sequence[int]] = None
 
     def position(self, state: np.ndarray) -> np.ndarray:
         state = np.asarray(state, float).reshape(-1)
-        px = state[self.x]
-        py = state[self.y]
-        pz = state[self.z] if self.z is not None else 0.0
-        return np.array([px, py, pz], dtype=float)
+        return np.array(
+            [
+                state[self.x],
+                state[self.y],
+                state[self.z] if self.z is not None else 0.0,
+            ],
+            dtype=float,
+        )
+
+    def rotation(self, state: np.ndarray) -> np.ndarray:
+        state = np.asarray(state, float).reshape(-1)
+        if self.quat is not None:
+            return rotation_from_quat([state[i] for i in self.quat])
+        if self.roll is None and self.pitch is None and self.yaw is None:
+            return IDENTITY.copy()
+        return rotation_from_euler(
+            roll=state[self.roll] if self.roll is not None else 0.0,
+            pitch=state[self.pitch] if self.pitch is not None else 0.0,
+            yaw=state[self.yaw] if self.yaw is not None else 0.0,
+        )
+
+    @property
+    def has_orientation(self) -> bool:
+        return self.quat is not None or any(
+            i is not None for i in (self.roll, self.pitch, self.yaw)
+        )
+
+    def transform(self, state: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        return self.rotation(state), self.position(state)
 
 
+# --------------------------------------------------------------------------- #
+# Robot / environment
+# --------------------------------------------------------------------------- #
 @dataclass
 class Robot:
-    """A robot as a collection of primitives plus a state->pose mapping."""
+    """A robot as a collection of shapes plus a state->pose mapping."""
 
     shapes: Sequence[Shape] = field(default_factory=list)
     pose: PoseMapping = field(default_factory=PoseMapping)
 
     def placed_shapes(self, state: np.ndarray) -> List[Shape]:
-        offset = self.pose.position(state)
-        return [s.translated(offset) for s in self.shapes]
+        rotation, translation = self.pose.transform(state)
+        return [s.transformed(rotation, translation) for s in self.shapes]
 
 
 @dataclass
 class Environment:
-    """World bounds and static obstacle primitives."""
+    """World bounds and static obstacle shapes."""
 
     bounds: np.ndarray  # (2, 3): [[xmin,ymin,zmin],[xmax,ymax,zmax]]
     obstacles: Sequence[Shape] = field(default_factory=list)
 
 
-class CollisionChecker:
-    """Broad-phase AABB reject + narrow-phase primitive tests."""
+def shapes_collide(a: Shape, b: Shape) -> bool:
+    """Narrow-phase collision test between two supported shapes."""
+    from .collision import shapes_intersect
 
-    def __init__(self, robot: Robot, environment: Environment) -> None:
+    return shapes_intersect(a, b)
+
+
+class CollisionChecker:
+    """Broad-phase AABB reject plus narrow-phase shape tests.
+
+    Uses the native (Rust/parry3d) collision scene when the compiled core is
+    available, and the pure-Python GJK narrow phase otherwise.
+    """
+
+    def __init__(self, robot: Robot, environment: Environment, use_accel: bool = True) -> None:
         self.robot = robot
         self.environment = environment
         self._obs_aabbs = [o.aabb() for o in environment.obstacles]
+        self.use_accel = bool(use_accel)
+        self._scene = None
+        if self.use_accel:
+            from . import accel
+
+            self._scene = accel.make_collision_scene(robot, environment)
+
+    @property
+    def backend(self) -> str:
+        return "rust" if self._scene is not None else "python"
 
     def in_collision(self, state: np.ndarray) -> bool:
-        placed = self.robot.placed_shapes(state)
-        for shape in placed:
+        if self._scene is not None:
+            rotation, translation = self.robot.pose.transform(state)
+            return bool(
+                self._scene.in_collision_at(
+                    np.ascontiguousarray(rotation, float).reshape(-1),
+                    np.ascontiguousarray(translation, float),
+                )
+            )
+        return self._in_collision_python(state)
+
+    def _in_collision_python(self, state: np.ndarray) -> bool:
+        from .collision import shapes_intersect
+
+        for shape in self.robot.placed_shapes(state):
             slo, shi = shape.aabb()
             for obs, (olo, ohi) in zip(self.environment.obstacles, self._obs_aabbs):
                 # Broad phase: skip clearly separated pairs.
                 if np.any(shi < olo) or np.any(slo > ohi):
                     continue
-                if shapes_collide(shape, obs):
+                if shapes_intersect(shape, obs):
                     return True
         return False
 
     def trajectory_in_collision(self, states: np.ndarray) -> bool:
         """Sampled collision check along a trajectory's states."""
-        for state in np.asarray(states, float):
-            if self.in_collision(state):
+        states = np.asarray(states, float)
+        if states.ndim == 1:
+            states = states.reshape(1, -1)
+        if self._scene is not None:
+            # Pose mapping stays in Python; the native scene only sees geometry.
+            n = states.shape[0]
+            rotations = np.empty((n, 9))
+            translations = np.empty((n, 3))
+            for i, state in enumerate(states):
+                rotation, translation = self.robot.pose.transform(state)
+                rotations[i] = np.asarray(rotation, float).reshape(-1)
+                translations[i] = translation
+            return bool(
+                self._scene.trajectory_in_collision(
+                    np.ascontiguousarray(rotations), np.ascontiguousarray(translations)
+                )
+            )
+        for state in states:
+            if self._in_collision_python(state):
                 return True
         return False

--- a/krrtstar/viz.py
+++ b/krrtstar/viz.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, List, Optional
 
 import numpy as np
 
-from .geometry import Box, PoseMapping, Sphere
+from .geometry import Box, Capsule, Cylinder, Mesh, PoseMapping, Sphere
 
 _MISSING_MSG = (
     "pyvista is required for visualization; install with `poetry install --with viz`"
@@ -40,17 +40,115 @@ def _require_pyvista():
 # --------------------------------------------------------------------------- #
 # Geometry -> mesh helpers
 # --------------------------------------------------------------------------- #
-def _shape_to_mesh(pyvista, shape: Any):
-    """Convert a :class:`Box` or :class:`Sphere` into a PyVista mesh."""
-    if isinstance(shape, Box):
-        center = np.asarray(shape.center, float).reshape(-1)
-        ex, ey, ez = (float(v) for v in np.asarray(shape.extents, float).reshape(-1))
-        return pyvista.Cube(
-            center=tuple(center), x_length=ex, y_length=ey, z_length=ez
+_LOCAL_Z = np.array([0.0, 0.0, 1.0])
+
+
+def _rotation_of(shape: Any) -> np.ndarray:
+    """Rotation matrix of a shape, defaulting to the identity."""
+    rotation = getattr(shape, "rotation", None)
+    if rotation is None:
+        return np.eye(3)
+    return np.asarray(rotation, float).reshape(3, 3)
+
+
+def _rigid_matrix(rotation: np.ndarray, translation: np.ndarray) -> np.ndarray:
+    """Compose a 4x4 homogeneous transform from a rotation and a translation."""
+    matrix = np.eye(4)
+    matrix[:3, :3] = rotation
+    matrix[:3, 3] = translation
+    return matrix
+
+
+def _axis_direction(shape: Any) -> np.ndarray:
+    """World-space direction of a shape's local Z axis (its symmetry axis)."""
+    return _rotation_of(shape) @ _LOCAL_Z
+
+
+def _box_mesh(pyvista, shape: Box):
+    """Cube built at the origin, then placed by the box's rotation + center."""
+    ex, ey, ez = (float(v) for v in np.asarray(shape.extents, float).reshape(-1))
+    try:
+        mesh = pyvista.Cube(
+            x_length=ex, y_length=ey, z_length=ez, point_dtype="float64"
         )
+    except TypeError:  # pragma: no cover - older PyVista without point_dtype
+        mesh = pyvista.Cube(x_length=ex, y_length=ey, z_length=ez)
+    center = np.asarray(shape.center, float).reshape(-1)
+    mesh.transform(_rigid_matrix(_rotation_of(shape), center), inplace=True)
+    return mesh
+
+
+def _capsule_mesh(pyvista, shape: Capsule):
+    """Capsule via ``pyvista.Capsule``, or a cylinder plus two end-cap spheres."""
+    center = np.asarray(shape.center, float).reshape(-1)
+    radius = float(shape.radius)
+    direction = _axis_direction(shape)
+    capsule = getattr(pyvista, "Capsule", None)
+    if capsule is not None:
+        try:
+            return capsule(
+                center=tuple(center),
+                direction=tuple(direction),
+                radius=radius,
+                cylinder_length=float(shape.height),
+            )
+        except TypeError:  # pragma: no cover - signature differs across versions
+            pass
+    start, end = shape.segment()
+    body = pyvista.Cylinder(
+        center=tuple(center),
+        direction=tuple(direction),
+        radius=radius,
+        height=float(shape.height),
+    )
+    caps = [
+        pyvista.Sphere(radius=radius, center=tuple(np.asarray(p, float)))
+        for p in (start, end)
+    ]
+    return body.merge(caps)
+
+
+def _cylinder_mesh(pyvista, shape: Cylinder):
+    center = np.asarray(shape.center, float).reshape(-1)
+    return pyvista.Cylinder(
+        center=tuple(center),
+        direction=tuple(_axis_direction(shape)),
+        radius=float(shape.radius),
+        height=float(shape.height),
+    )
+
+
+def _triangle_mesh(pyvista, shape: Mesh):
+    """Triangle soup as ``PolyData``, using the mesh's world-frame vertices."""
+    vertices = np.asarray(shape.world_vertices(), float).reshape(-1, 3)
+    faces = np.asarray(shape.faces, np.int64).reshape(-1, 3)
+    # VTK cell array: each triangle is prefixed by its vertex count.
+    cells = np.hstack(
+        [np.full((faces.shape[0], 1), 3, dtype=np.int64), faces]
+    ).ravel()
+    return pyvista.PolyData(vertices, cells)
+
+
+def _shape_to_mesh(pyvista, shape: Any):
+    """Convert a :mod:`krrtstar.geometry` shape into a PyVista mesh.
+
+    Handles :class:`Sphere`, :class:`Box` (oriented or not), :class:`Capsule`,
+    :class:`Cylinder` and triangle :class:`Mesh`.
+
+    Raises:
+        TypeError: for shape types that cannot be rendered. Callers skip those.
+    """
+    if isinstance(shape, Box):
+        return _box_mesh(pyvista, shape)
     if isinstance(shape, Sphere):
         center = np.asarray(shape.center, float).reshape(-1)
         return pyvista.Sphere(radius=float(shape.radius), center=tuple(center))
+    if isinstance(shape, Capsule):
+        return _capsule_mesh(pyvista, shape)
+    if isinstance(shape, Cylinder):
+        return _cylinder_mesh(pyvista, shape)
+    if isinstance(shape, Mesh):
+        return _triangle_mesh(pyvista, shape)
     raise TypeError(f"Unsupported shape for rendering: {type(shape)!r}")
 
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +18,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bytemuck"
@@ -24,10 +42,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -51,6 +138,7 @@ dependencies = [
  "nalgebra",
  "ndarray",
  "numpy",
+ "parry3d-f64",
  "pyo3",
 ]
 
@@ -59,6 +147,18 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matrixmultiply"
@@ -141,6 +241,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -181,7 +293,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -189,6 +301,41 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parry3d-f64"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4484c8ad93ff03c0e57aa1a4f3ff5406ab6301a1eb838ef6dea90e94f00a6c7"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags",
+ "downcast-rs",
+ "either",
+ "ena",
+ "log",
+ "nalgebra",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rstar",
+ "rustc-hash 2.1.3",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "thiserror",
+]
 
 [[package]]
 name = "paste"
@@ -299,10 +446,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
@@ -333,6 +503,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +548,26 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "typenum"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,3 +12,7 @@ pyo3 = { version = "0.22", features = ["extension-module", "abi3-py310"] }
 numpy = "0.22"
 nalgebra = "0.33"
 ndarray = "0.16"
+# The 64-bit build of parry3d, renamed so the code reads `parry3d::`. It shares
+# nalgebra 0.33 with this crate, and matches the float64 Python shape model
+# (plain `parry3d` is single precision).
+parry3d = { package = "parry3d-f64", version = "0.17" }

--- a/rust/src/collision.rs
+++ b/rust/src/collision.rs
@@ -1,0 +1,394 @@
+//! Native collision scene backed by parry3d.
+//!
+//! A scene holds two shape sets: the *robot* shapes, expressed in the robot
+//! frame, and the *obstacle* shapes, expressed in world coordinates. A query
+//! supplies the robot's world transform, so the planner's state -> pose mapping
+//! stays on the Python side (see `krrtstar.geometry.PoseMapping`).
+//!
+//! Axis conventions differ between the Python shape model and parry:
+//! `krrtstar.geometry.Capsule`/`Cylinder` put their axis on the local **Z**
+//! axis, whereas parry's `Capsule`/`Cylinder` are aligned with **Y**. Every
+//! such shape therefore carries an extra rotation mapping Z onto Y (see
+//! [`Z_TO_Y`]).
+//!
+//! The `parry3d` dependency is the 64-bit build (`parry3d-f64` renamed to
+//! `parry3d`): the Python model is `float64` throughout, and the pure-Python
+//! GJK narrow phase is the reference these results are compared against, so
+//! single precision would introduce disagreements well above the geometric
+//! tolerances used there.
+
+use std::f64::consts::FRAC_PI_2;
+
+use nalgebra::{Isometry3, Matrix3, Point3, Rotation3, Translation3, UnitQuaternion, Vector3};
+use numpy::{PyReadonlyArray1, PyReadonlyArray2};
+use parry3d::bounding_volume::{Aabb, BoundingVolume};
+use parry3d::query::intersection_test;
+use parry3d::shape::{Ball, Capsule, Cuboid, Cylinder, SharedShape, TriMesh};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+/// Rotation taking the local Z axis onto the local Y axis, i.e. from the
+/// Python (Z-aligned) capsule/cylinder frame into parry's (Y-aligned) one.
+///
+/// Both shapes are symmetric about their centre, so the sign of the resulting
+/// axis is irrelevant.
+fn z_to_y() -> Rotation3<f64> {
+    Rotation3::from_axis_angle(&Vector3::x_axis(), -FRAC_PI_2)
+}
+
+/// One registered shape together with its placement in the frame it was added
+/// in (the robot frame for robot shapes, the world frame for obstacles).
+struct Entry {
+    shape: SharedShape,
+    iso: Isometry3<f64>,
+    /// AABB of `shape` at `iso`, in that same frame.
+    aabb: Aabb,
+}
+
+impl Entry {
+    fn new(shape: SharedShape, iso: Isometry3<f64>) -> Self {
+        let aabb = shape.compute_aabb(&iso);
+        Self { shape, iso, aabb }
+    }
+}
+
+/// Which set a shape belongs to.
+enum Side {
+    Robot,
+    Obstacle,
+}
+
+fn parse_side(side: &str) -> PyResult<Side> {
+    match side {
+        "robot" => Ok(Side::Robot),
+        "obstacle" => Ok(Side::Obstacle),
+        other => Err(PyValueError::new_err(format!(
+            "side must be 'robot' or 'obstacle', got {other:?}"
+        ))),
+    }
+}
+
+/// Read a 3-vector, rejecting any other length.
+fn read_vec3(arr: &PyReadonlyArray1<f64>, name: &str) -> PyResult<Vector3<f64>> {
+    let a = arr.as_array();
+    if a.len() != 3 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must have 3 elements, got {}",
+            a.len()
+        )));
+    }
+    Ok(Vector3::new(a[0], a[1], a[2]))
+}
+
+/// Read a 3x3 rotation matrix flattened row-major into nine values.
+fn read_rotation(rot9: &PyReadonlyArray1<f64>) -> PyResult<Rotation3<f64>> {
+    let r = rot9.as_array();
+    if r.len() != 9 {
+        return Err(PyValueError::new_err(format!(
+            "rotation must be a flattened 3x3 matrix (9 elements), got {}",
+            r.len()
+        )));
+    }
+    // `Matrix3::new` takes its arguments row-major, matching the input layout.
+    let m = Matrix3::new(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]);
+    Ok(Rotation3::from_matrix_unchecked(m))
+}
+
+fn isometry(rotation: Rotation3<f64>, translation: Vector3<f64>) -> Isometry3<f64> {
+    Isometry3::from_parts(
+        Translation3::from(translation),
+        UnitQuaternion::from_rotation_matrix(&rotation),
+    )
+}
+
+/// Reject non-finite or non-positive shape dimensions early: parry panics or
+/// silently misbehaves on degenerate shapes.
+fn check_positive(value: f64, name: &str) -> PyResult<()> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be finite and positive, got {value}"
+        )));
+    }
+    Ok(())
+}
+
+/// A collision scene: robot shapes in the robot frame, obstacles in world
+/// coordinates.
+#[pyclass]
+pub struct CollisionScene {
+    robot: Vec<Entry>,
+    obstacles: Vec<Entry>,
+    /// Union of all obstacle AABBs, used as a cheap first reject.
+    obstacle_bound: Option<Aabb>,
+}
+
+impl CollisionScene {
+    fn push(&mut self, side: Side, entry: Entry) {
+        match side {
+            Side::Robot => self.robot.push(entry),
+            Side::Obstacle => {
+                self.obstacles.push(entry);
+                self.obstacle_bound = None;
+            }
+        }
+    }
+
+    /// True when any robot shape, placed by `query`, intersects an obstacle.
+    fn collides(&self, query: &Isometry3<f64>) -> PyResult<bool> {
+        for r in &self.robot {
+            let world = query * r.iso;
+            let aabb = r.shape.compute_aabb(&world);
+            if let Some(bound) = &self.obstacle_bound {
+                if !aabb.intersects(bound) {
+                    continue;
+                }
+            }
+            for o in &self.obstacles {
+                // Broad phase: skip clearly separated pairs.
+                if !aabb.intersects(&o.aabb) {
+                    continue;
+                }
+                let hit = intersection_test(&world, r.shape.as_ref(), &o.iso, o.shape.as_ref())
+                    .map_err(|_| {
+                        PyRuntimeError::new_err(
+                            "parry3d does not support an intersection test between this pair of shapes",
+                        )
+                    })?;
+                if hit {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[pymethods]
+impl CollisionScene {
+    #[new]
+    fn new() -> Self {
+        Self {
+            robot: Vec::new(),
+            obstacles: Vec::new(),
+            obstacle_bound: None,
+        }
+    }
+
+    fn add_sphere(
+        &mut self,
+        side: &str,
+        center: PyReadonlyArray1<f64>,
+        radius: f64,
+    ) -> PyResult<()> {
+        let side = parse_side(side)?;
+        let center = read_vec3(&center, "center")?;
+        check_positive(radius, "radius")?;
+        let iso = isometry(Rotation3::identity(), center);
+        self.push(side, Entry::new(SharedShape::new(Ball::new(radius)), iso));
+        Ok(())
+    }
+
+    fn add_box(
+        &mut self,
+        side: &str,
+        center: PyReadonlyArray1<f64>,
+        rot9: PyReadonlyArray1<f64>,
+        extents: PyReadonlyArray1<f64>,
+    ) -> PyResult<()> {
+        let side = parse_side(side)?;
+        let center = read_vec3(&center, "center")?;
+        let rotation = read_rotation(&rot9)?;
+        let extents = read_vec3(&extents, "extents")?;
+        for (i, e) in extents.iter().enumerate() {
+            check_positive(*e, &format!("extents[{i}]"))?;
+        }
+        let iso = isometry(rotation, center);
+        self.push(
+            side,
+            Entry::new(SharedShape::new(Cuboid::new(extents / 2.0)), iso),
+        );
+        Ok(())
+    }
+
+    /// `height` is the length of the inner segment, excluding the end caps,
+    /// matching `krrtstar.geometry.Capsule`.
+    fn add_capsule(
+        &mut self,
+        side: &str,
+        center: PyReadonlyArray1<f64>,
+        rot9: PyReadonlyArray1<f64>,
+        radius: f64,
+        height: f64,
+    ) -> PyResult<()> {
+        let side = parse_side(side)?;
+        let center = read_vec3(&center, "center")?;
+        let rotation = read_rotation(&rot9)?;
+        check_positive(radius, "radius")?;
+        check_positive(height, "height")?;
+        let iso = isometry(rotation * z_to_y(), center);
+        self.push(
+            side,
+            Entry::new(SharedShape::new(Capsule::new_y(height / 2.0, radius)), iso),
+        );
+        Ok(())
+    }
+
+    /// `height` is the full height, matching `krrtstar.geometry.Cylinder`.
+    fn add_cylinder(
+        &mut self,
+        side: &str,
+        center: PyReadonlyArray1<f64>,
+        rot9: PyReadonlyArray1<f64>,
+        radius: f64,
+        height: f64,
+    ) -> PyResult<()> {
+        let side = parse_side(side)?;
+        let center = read_vec3(&center, "center")?;
+        let rotation = read_rotation(&rot9)?;
+        check_positive(radius, "radius")?;
+        check_positive(height, "height")?;
+        let iso = isometry(rotation * z_to_y(), center);
+        self.push(
+            side,
+            Entry::new(SharedShape::new(Cylinder::new(height / 2.0, radius)), iso),
+        );
+        Ok(())
+    }
+
+    fn add_mesh(
+        &mut self,
+        side: &str,
+        center: PyReadonlyArray1<f64>,
+        rot9: PyReadonlyArray1<f64>,
+        vertices: PyReadonlyArray2<f64>,
+        faces: PyReadonlyArray2<u32>,
+        scale: f64,
+    ) -> PyResult<()> {
+        let side = parse_side(side)?;
+        let center = read_vec3(&center, "center")?;
+        let rotation = read_rotation(&rot9)?;
+        if !scale.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "scale must be finite, got {scale}"
+            )));
+        }
+
+        let v = vertices.as_array();
+        let f = faces.as_array();
+        if v.ncols() != 3 {
+            return Err(PyValueError::new_err(format!(
+                "vertices must be (n, 3), got (_, {})",
+                v.ncols()
+            )));
+        }
+        if f.ncols() != 3 {
+            return Err(PyValueError::new_err(format!(
+                "faces must be (m, 3), got (_, {})",
+                f.ncols()
+            )));
+        }
+        if v.nrows() == 0 || f.nrows() == 0 {
+            return Err(PyValueError::new_err(
+                "mesh must have at least one vertex and one face",
+            ));
+        }
+
+        let points: Vec<Point3<f64>> = (0..v.nrows())
+            .map(|i| Point3::new(v[[i, 0]] * scale, v[[i, 1]] * scale, v[[i, 2]] * scale))
+            .collect();
+        let mut indices: Vec<[u32; 3]> = Vec::with_capacity(f.nrows());
+        for i in 0..f.nrows() {
+            let tri = [f[[i, 0]], f[[i, 1]], f[[i, 2]]];
+            for idx in tri {
+                if idx as usize >= points.len() {
+                    return Err(PyValueError::new_err(format!(
+                        "face index {idx} is out of range for {} vertices",
+                        points.len()
+                    )));
+                }
+            }
+            indices.push(tri);
+        }
+
+        let iso = isometry(rotation, center);
+        self.push(
+            side,
+            Entry::new(SharedShape::new(TriMesh::new(points, indices)), iso),
+        );
+        Ok(())
+    }
+
+    /// Precompute the broad-phase bound over all obstacles.
+    fn finalize(&mut self) {
+        self.obstacle_bound = self.obstacles.iter().fold(None, |acc, o| match acc {
+            None => Some(o.aabb),
+            Some(bound) => Some(bound.merged(&o.aabb)),
+        });
+    }
+
+    /// True when the robot, placed at `(rot9, translation)`, collides with any
+    /// obstacle. Exact touching counts as a collision.
+    fn in_collision_at(
+        &self,
+        rot9: PyReadonlyArray1<f64>,
+        translation: PyReadonlyArray1<f64>,
+    ) -> PyResult<bool> {
+        let rotation = read_rotation(&rot9)?;
+        let translation = read_vec3(&translation, "translation")?;
+        self.collides(&isometry(rotation, translation))
+    }
+
+    /// True as soon as one pose of the sampled trajectory collides.
+    ///
+    /// `rot9s` is `(n, 9)` (row-major 3x3 rotations) and `translations` is
+    /// `(n, 3)`.
+    fn trajectory_in_collision(
+        &self,
+        rot9s: PyReadonlyArray2<f64>,
+        translations: PyReadonlyArray2<f64>,
+    ) -> PyResult<bool> {
+        let r = rot9s.as_array();
+        let t = translations.as_array();
+        if r.ncols() != 9 {
+            return Err(PyValueError::new_err(format!(
+                "rot9s must be (n, 9), got (_, {})",
+                r.ncols()
+            )));
+        }
+        if t.ncols() != 3 {
+            return Err(PyValueError::new_err(format!(
+                "translations must be (n, 3), got (_, {})",
+                t.ncols()
+            )));
+        }
+        if r.nrows() != t.nrows() {
+            return Err(PyValueError::new_err(format!(
+                "rot9s and translations must have the same number of rows, got {} and {}",
+                r.nrows(),
+                t.nrows()
+            )));
+        }
+
+        for i in 0..r.nrows() {
+            let m = Matrix3::new(
+                r[[i, 0]],
+                r[[i, 1]],
+                r[[i, 2]],
+                r[[i, 3]],
+                r[[i, 4]],
+                r[[i, 5]],
+                r[[i, 6]],
+                r[[i, 7]],
+                r[[i, 8]],
+            );
+            let iso = isometry(
+                Rotation3::from_matrix_unchecked(m),
+                Vector3::new(t[[i, 0]], t[[i, 1]], t[[i, 2]]),
+            );
+            if self.collides(&iso)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides the optimal-time connection for linear systems
 //!     x_dot = A x + B u + c,   cost = integral_0^tau (1 + u^T R u) dt
 //! including full trajectory reconstruction, plus a Euclidean neighbour
-//! pre-filter.
+//! pre-filter and the parry3d-backed collision scene in [`collision`].
 //!
 //! The key performance property exploited here: the matrix integrals
 //! `Phi(t) = e^{A t}`, `Ad(t) = int_0^t e^{A s} ds` and the weighted
@@ -12,9 +12,13 @@
 //! fixed time grid and reuses them for every cost query, which turns each
 //! query into a handful of matrix-vector products.
 
+mod collision;
+
 use nalgebra::{DMatrix, DVector};
 use numpy::{PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
+
+use collision::CollisionScene;
 
 /// Convert a numpy 2D float64 array view into an nalgebra DMatrix.
 fn to_dmatrix(arr: &PyReadonlyArray2<f64>) -> DMatrix<f64> {
@@ -583,5 +587,6 @@ fn krrtstar_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(linear_cost, m)?)?;
     m.add_function(wrap_pyfunction!(linear_connect, m)?)?;
     m.add_class::<LinearConnector>()?;
+    m.add_class::<CollisionScene>()?;
     Ok(())
 }

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -1,0 +1,1038 @@
+"""Tests for the pure-Python GJK narrow phase in :mod:`krrtstar.collision`.
+
+Expected values come from analytic geometry or from independent reference
+implementations written below (point-to-OBB distance, segment-segment distance,
+an OBB separating-axis test, and an exact feature-enumeration OBB-OBB distance),
+never from the code under test.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+
+from krrtstar.collision import (
+    _closest_point_on_edges,
+    _Triangle,
+    closest_point_on_segment,
+    closest_point_on_tetrahedron,
+    closest_point_on_triangle,
+    gjk_distance,
+    shapes_distance,
+    shapes_intersect,
+)
+from krrtstar.geometry import (
+    Box,
+    Capsule,
+    Cylinder,
+    Mesh,
+    Sphere,
+    rotation_from_euler,
+    shapes_collide,
+)
+
+TOL = 1e-9
+SQRT2 = np.sqrt(2.0)
+SQRT3 = np.sqrt(3.0)
+
+
+# --------------------------------------------------------------------------- #
+# Reference implementations (independent of the code under test)
+# --------------------------------------------------------------------------- #
+def ref_point_obb_distance(point, box):
+    """Exact distance from a point to a (possibly oriented) box."""
+    local = box.rotation.T @ (np.asarray(point, float) - box.center)
+    outside = np.maximum(0.0, np.abs(local) - box.half_extents)
+    return float(np.linalg.norm(outside))
+
+
+def ref_segment_segment_distance(p1, q1, p2, q2):
+    """Exact distance between two segments (clamped closed form)."""
+    p1, q1, p2, q2 = (np.asarray(v, float) for v in (p1, q1, p2, q2))
+    d1, d2, r = q1 - p1, q2 - p2, p1 - p2
+    a, e, f = float(d1 @ d1), float(d2 @ d2), float(d2 @ r)
+    if a <= 1e-300 and e <= 1e-300:
+        return float(np.linalg.norm(r))
+    if a <= 1e-300:
+        s, t = 0.0, np.clip(f / e, 0.0, 1.0)
+    elif e <= 1e-300:
+        s, t = np.clip(-float(d1 @ r) / a, 0.0, 1.0), 0.0
+    else:
+        c = float(d1 @ r)
+        b = float(d1 @ d2)
+        denom = a * e - b * b
+        s = np.clip((b * f - c * e) / denom, 0.0, 1.0) if denom > 1e-300 else 0.0
+        t = (b * s + f) / e
+        if t < 0.0:
+            t, s = 0.0, np.clip(-c / a, 0.0, 1.0)
+        elif t > 1.0:
+            t, s = 1.0, np.clip((b - c) / a, 0.0, 1.0)
+    return float(np.linalg.norm((p1 + s * d1) - (p2 + t * d2)))
+
+
+def ref_point_triangle_distance(point, tri):
+    """Exact point-triangle distance via a plane projection with edge fallback."""
+    point = np.asarray(point, float)
+    a, b, c = (np.asarray(v, float) for v in tri)
+    ab, ac, w = b - a, c - a, point - a
+    d1, d2, d3 = float(ab @ ab), float(ab @ ac), float(ac @ ac)
+    det = d1 * d3 - d2 * d2
+    if det > 1e-24:
+        r1, r2 = float(w @ ab), float(w @ ac)
+        u = (d3 * r1 - d2 * r2) / det
+        v = (d1 * r2 - d2 * r1) / det
+        if u >= 0.0 and v >= 0.0 and u + v <= 1.0:
+            return float(np.linalg.norm(w - u * ab - v * ac))
+    return min(
+        ref_segment_segment_distance(a, b, point, point),
+        ref_segment_segment_distance(b, c, point, point),
+        ref_segment_segment_distance(a, c, point, point),
+    )
+
+
+def ref_triangle_triangle_distance(t1, t2):
+    """Exact distance between two disjoint triangles by feature enumeration."""
+    best = min(
+        min(ref_point_triangle_distance(v, t2) for v in t1),
+        min(ref_point_triangle_distance(v, t1) for v in t2),
+    )
+    for i in range(3):
+        for j in range(3):
+            best = min(
+                best,
+                ref_segment_segment_distance(
+                    t1[i], t1[(i + 1) % 3], t2[j], t2[(j + 1) % 3]
+                ),
+            )
+    return best
+
+
+def ref_mesh_sphere_distance(mesh, sphere):
+    tris = mesh.triangles()
+    closest = min(ref_point_triangle_distance(sphere.center, t) for t in tris)
+    return max(0.0, closest - sphere.radius)
+
+
+def ref_mesh_mesh_distance(a, b):
+    ta, tb = a.triangles(), b.triangles()
+    return min(ref_triangle_triangle_distance(t1, t2) for t1 in ta for t2 in tb)
+
+
+def ref_edge_pierces_unit_square(mesh, z=0.0, lo=0.0, hi=1.0):
+    """True when some mesh edge crosses the plane inside ``[lo, hi]^2``."""
+    for tri in mesh.triangles():
+        for i in range(3):
+            p, q = tri[i], tri[(i + 1) % 3]
+            if (p[2] - z) * (q[2] - z) < 0.0:
+                point = p + ((z - p[2]) / (q[2] - p[2])) * (q - p)
+                if lo <= point[0] <= hi and lo <= point[1] <= hi:
+                    return True
+    return False
+
+
+def ref_segment_segment_distance_sampled(p1, q1, p2, q2, n=1200):
+    """Brute-force cross-check for :func:`ref_segment_segment_distance`."""
+    ts = np.linspace(0.0, 1.0, n)
+    a = np.asarray(p1, float) + ts[:, None] * (np.asarray(q1, float) - np.asarray(p1, float))
+    b = np.asarray(p2, float) + ts[:, None] * (np.asarray(q2, float) - np.asarray(p2, float))
+    return float(np.sqrt(((a[:, None, :] - b[None, :, :]) ** 2).sum(-1)).min())
+
+
+def box_edges(box):
+    """The 12 edges of a box as ``(12, 2, 3)`` world-frame endpoints."""
+    corners = box.core_points()  # ordered by (sx, sy, sz) bit pattern
+    edges = []
+    for i, j in itertools.combinations(range(8), 2):
+        if bin(i ^ j).count("1") == 1:
+            edges.append([corners[i], corners[j]])
+    return np.asarray(edges, float)
+
+
+def ref_obb_overlap(a, b):
+    """Separating-axis test: exact overlap predicate for two oriented boxes."""
+    axes = [a.rotation[:, i] for i in range(3)] + [b.rotation[:, i] for i in range(3)]
+    for i in range(3):
+        for j in range(3):
+            axis = np.cross(a.rotation[:, i], b.rotation[:, j])
+            if float(axis @ axis) > 1e-18:
+                axes.append(axis)
+    delta = b.center - a.center
+    for axis in axes:
+        axis = axis / np.linalg.norm(axis)
+        ra = float(np.abs(a.rotation.T @ axis) @ a.half_extents)
+        rb = float(np.abs(b.rotation.T @ axis) @ b.half_extents)
+        if abs(float(delta @ axis)) > ra + rb:
+            return False
+    return True
+
+
+def ref_obb_distance(a, b):
+    """Exact distance between two *disjoint* boxes by feature enumeration.
+
+    For disjoint convex polytopes the closest pair is realised by a
+    vertex/face or an edge/edge pair, so enumerating both suffices.
+    """
+    best = min(
+        min(ref_point_obb_distance(v, b) for v in a.core_points()),
+        min(ref_point_obb_distance(v, a) for v in b.core_points()),
+    )
+    ea, eb = box_edges(a), box_edges(b)
+    for sa in ea:
+        for sb in eb:
+            best = min(best, ref_segment_segment_distance(sa[0], sa[1], sb[0], sb[1]))
+    return best
+
+
+def test_reference_segment_distance_matches_brute_force():
+    rng = np.random.default_rng(7)
+    for _ in range(20):
+        pts = rng.uniform(-2.0, 2.0, size=(4, 3))
+        exact = ref_segment_segment_distance(*pts)
+        sampled = ref_segment_segment_distance_sampled(*pts)
+        assert exact <= sampled + 1e-12
+        assert sampled - exact < 1e-4
+
+
+# --------------------------------------------------------------------------- #
+# Simplex closest-point helpers
+# --------------------------------------------------------------------------- #
+def brute_closest_on_simplex(points, n=60):
+    """Brute-force closest point to the origin on a convex combination grid."""
+    points = np.asarray(points, float)
+    k = points.shape[0]
+    grids = np.meshgrid(*[np.linspace(0.0, 1.0, n)] * (k - 1), indexing="ij")
+    weights = np.stack([g.ravel() for g in grids], axis=1)
+    keep = weights.sum(axis=1) <= 1.0 + 1e-12
+    weights = weights[keep]
+    full = np.hstack([1.0 - weights.sum(axis=1, keepdims=True), weights])
+    pts = full @ points
+    return float(np.linalg.norm(pts, axis=1).min())
+
+
+def test_closest_point_on_segment_regions():
+    a = np.array([1.0, 1.0, 0.0])
+    b = np.array([3.0, 1.0, 0.0])
+    point, kept = closest_point_on_segment(a, b)
+    assert kept == (0,)
+    assert np.allclose(point, a)
+
+    point, kept = closest_point_on_segment(np.array([-3.0, 1.0, 0.0]), np.array([-1.0, 1.0, 0.0]))
+    assert kept == (1,)
+    assert np.allclose(point, [-1.0, 1.0, 0.0])
+
+    point, kept = closest_point_on_segment(np.array([-1.0, 2.0, 0.0]), np.array([1.0, 2.0, 0.0]))
+    assert kept == (0, 1)
+    assert np.allclose(point, [0.0, 2.0, 0.0])
+
+    # Degenerate segment (both endpoints coincide).
+    point, kept = closest_point_on_segment(a, a.copy())
+    assert kept == (0,)
+    assert np.allclose(point, a)
+
+
+def test_closest_point_on_triangle_regions():
+    # Triangle in the z = 1 plane; the origin projects inside it.
+    a = np.array([-1.0, -1.0, 1.0])
+    b = np.array([2.0, -1.0, 1.0])
+    c = np.array([-1.0, 2.0, 1.0])
+    point, kept = closest_point_on_triangle(a, b, c)
+    assert kept == (0, 1, 2)
+    assert np.allclose(point, [0.0, 0.0, 1.0])
+
+    # Vertex region.
+    shifted = [v + np.array([3.0, 3.0, 0.0]) for v in (a, b, c)]
+    point, kept = closest_point_on_triangle(*shifted)
+    assert kept == (0,)
+    assert np.allclose(point, shifted[0])
+
+    # Edge region: origin closest to the interior of edge BC.
+    a2 = np.array([0.0, 0.0, 3.0])
+    b2 = np.array([-1.0, 0.0, 1.0])
+    c2 = np.array([1.0, 0.0, 1.0])
+    point, kept = closest_point_on_triangle(a2, b2, c2)
+    assert kept == (1, 2)
+    assert np.allclose(point, [0.0, 0.0, 1.0])
+
+    # Degenerate (collinear) triangle behaves like the containing segment.
+    point, kept = closest_point_on_triangle(
+        np.array([-1.0, 1.0, 0.0]), np.array([0.0, 1.0, 0.0]), np.array([1.0, 1.0, 0.0])
+    )
+    assert np.allclose(np.linalg.norm(point), 1.0)
+
+
+def test_closest_point_on_triangle_matches_brute_force():
+    rng = np.random.default_rng(11)
+    for _ in range(30):
+        pts = rng.uniform(-2.0, 2.0, size=(3, 3))
+        point, _ = closest_point_on_triangle(*pts)
+        exact = float(np.linalg.norm(point))
+        assert exact <= brute_closest_on_simplex(pts) + 1e-9
+
+
+def test_closest_point_on_tetrahedron_inside_and_outside():
+    verts = np.array(
+        [[1.0, 1.0, 1.0], [-1.0, 1.0, 1.0], [0.0, -1.0, 1.0], [0.0, 0.0, -1.0]]
+    )
+    point, kept = closest_point_on_tetrahedron(*verts)
+    assert kept == (0, 1, 2, 3)
+    assert np.allclose(point, 0.0)
+
+    outside = verts + np.array([0.0, 0.0, 4.0])
+    point, kept = closest_point_on_tetrahedron(*outside)
+    assert len(kept) < 4
+    assert np.isclose(float(np.linalg.norm(point)), 3.0)
+
+    # Degenerate (planar) tetrahedron: closest point lies on the plane.
+    planar = np.array(
+        [[0.0, 0.0, 2.0], [1.0, 0.0, 2.0], [0.0, 1.0, 2.0], [1.0, 1.0, 2.0]]
+    )
+    point, kept = closest_point_on_tetrahedron(*planar)
+    assert np.isclose(float(np.linalg.norm(point)), 2.0)
+
+
+def test_closest_point_on_edges_fallback():
+    """Safety net used when a triangle is too degenerate for the face branch."""
+    verts = (
+        np.array([-1.0, 2.0, 0.0]),
+        np.array([1.0, 2.0, 0.0]),
+        np.array([0.0, 5.0, 0.0]),
+    )
+    point, kept = _closest_point_on_edges(verts, ((0, 1), (0, 2), (1, 2)))
+    assert kept == (0, 1)
+    assert np.allclose(point, [0.0, 2.0, 0.0])
+
+    point, kept = _closest_point_on_edges(verts, ((0, 2), (1, 2)))
+    assert kept in {(0,), (1,)}
+    assert np.isclose(float(np.linalg.norm(point)), np.sqrt(5.0))
+
+
+def test_closest_point_on_tetrahedron_matches_brute_force():
+    rng = np.random.default_rng(13)
+    for _ in range(20):
+        pts = rng.uniform(-2.0, 2.0, size=(4, 3)) + np.array([0.0, 0.0, 3.0])
+        point, _ = closest_point_on_tetrahedron(*pts)
+        exact = float(np.linalg.norm(point))
+        assert exact <= brute_closest_on_simplex(pts, n=30) + 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Sphere / sphere
+# --------------------------------------------------------------------------- #
+def test_sphere_sphere_separated():
+    a = Sphere([0.0, 0.0, 0.0], 1.0)
+    b = Sphere([5.0, 0.0, 0.0], 1.5)
+    assert shapes_distance(a, b) == pytest.approx(2.5, abs=TOL)
+    assert not shapes_intersect(a, b)
+    # The GJK call sees only the cores (two points), i.e. the centre distance.
+    assert gjk_distance(a, b) == pytest.approx(5.0, abs=TOL)
+
+
+def test_sphere_sphere_touching_counts_as_collision():
+    a = Sphere([0.0, 0.0, 0.0], 1.0)
+    b = Sphere([2.0, 0.0, 0.0], 1.0)
+    assert shapes_distance(a, b) == pytest.approx(0.0, abs=TOL)
+    assert shapes_intersect(a, b)
+
+
+def test_sphere_sphere_overlapping():
+    a = Sphere([0.0, 0.0, 0.0], 1.0)
+    b = Sphere([1.0, 1.0, 1.0], 1.0)
+    assert shapes_distance(a, b) == 0.0
+    assert shapes_intersect(a, b)
+    # Fully contained.
+    assert shapes_intersect(Sphere([0.1, 0.0, 0.0], 0.2), a)
+
+
+def test_sphere_sphere_diagonal_distance():
+    a = Sphere([1.0, 2.0, 3.0], 0.25)
+    b = Sphere([4.0, 6.0, 3.0], 0.75)
+    assert shapes_distance(a, b) == pytest.approx(5.0 - 1.0, abs=TOL)
+
+
+# --------------------------------------------------------------------------- #
+# Sphere / box
+# --------------------------------------------------------------------------- #
+def test_sphere_axis_aligned_box_features():
+    box = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])  # half extents of 1
+
+    face = Sphere([3.0, 0.0, 0.0], 0.5)
+    assert shapes_distance(face, box) == pytest.approx(1.5, abs=TOL)
+
+    edge = Sphere([3.0, 3.0, 0.0], 0.5)
+    assert shapes_distance(edge, box) == pytest.approx(2.0 * SQRT2 - 0.5, abs=TOL)
+
+    corner = Sphere([3.0, 3.0, 3.0], 0.5)
+    assert shapes_distance(corner, box) == pytest.approx(2.0 * SQRT3 - 0.5, abs=TOL)
+
+    for shape in (face, edge, corner):
+        assert not shapes_intersect(shape, box)
+        assert ref_point_obb_distance(shape.center, box) - shape.radius == pytest.approx(
+            shapes_distance(shape, box), abs=TOL
+        )
+
+
+def test_sphere_box_touching_and_containment():
+    box = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    touching = Sphere([1.5, 0.0, 0.0], 0.5)
+    assert shapes_distance(touching, box) == pytest.approx(0.0, abs=TOL)
+    assert shapes_intersect(touching, box)
+
+    contained = Sphere([0.2, -0.1, 0.3], 0.25)
+    assert shapes_distance(contained, box) == 0.0
+    assert shapes_intersect(contained, box)
+
+    # A box fully inside a sphere.
+    big = Sphere([0.0, 0.0, 0.0], 5.0)
+    assert shapes_intersect(big, box)
+    assert shapes_distance(big, box) == 0.0
+
+
+def test_sphere_oriented_box_honours_rotation():
+    """A box rotated 45 deg about Z reaches sqrt(2) along +x, unrotated only 1."""
+    extents = [2.0, 2.0, 2.0]
+    plain = Box([0.0, 0.0, 0.0], extents)
+    rotated = Box([0.0, 0.0, 0.0], extents, rotation_from_euler(yaw=np.pi / 4))
+
+    probe = Sphere([1.5, 0.0, 0.0], 0.2)
+    assert shapes_intersect(probe, rotated)
+    assert not shapes_intersect(probe, plain)
+    assert shapes_distance(probe, plain) == pytest.approx(0.5 - 0.2, abs=TOL)
+
+    # Separated along the rotated diagonal: distance is measured to the corner.
+    far = Sphere([2.0, 0.0, 0.0], 0.2)
+    assert shapes_distance(far, rotated) == pytest.approx(2.0 - SQRT2 - 0.2, abs=TOL)
+    # ... and along the rotated face normal the box only reaches 1.0.
+    side = Sphere([1.5 / SQRT2, 1.5 / SQRT2, 0.0], 0.2)
+    assert shapes_distance(side, rotated) == pytest.approx(0.5 - 0.2, abs=TOL)
+    assert shapes_intersect(side, plain)  # the unrotated box does reach there
+
+
+def test_sphere_oriented_box_random_positions():
+    rng = np.random.default_rng(17)
+    box = Box([0.3, -0.2, 0.1], [1.0, 2.0, 0.5], rotation_from_euler(0.3, -0.7, 1.1))
+    for _ in range(200):
+        centre = rng.uniform(-3.0, 3.0, size=3)
+        radius = float(rng.uniform(0.0, 0.5))
+        sphere = Sphere(centre, radius)
+        expected = max(0.0, ref_point_obb_distance(centre, box) - radius)
+        assert shapes_distance(sphere, box) == pytest.approx(expected, abs=1e-9)
+        if abs(expected) > 1e-6:
+            assert shapes_intersect(sphere, box) == (expected == 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Box / box
+# --------------------------------------------------------------------------- #
+def test_axis_aligned_box_box():
+    a = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    overlapping = Box([1.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    separated = Box([5.0, 0.0, 0.0], [1.0, 1.0, 1.0])
+    touching = Box([2.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+
+    assert shapes_intersect(a, overlapping)
+    assert shapes_distance(a, overlapping) == 0.0
+
+    assert not shapes_intersect(a, separated)
+    assert shapes_distance(a, separated) == pytest.approx(3.5, abs=TOL)
+
+    assert shapes_intersect(a, touching)
+    assert shapes_distance(a, touching) == pytest.approx(0.0, abs=TOL)
+
+    # Diagonal separation: closest features are two corners.
+    diagonal = Box([3.0, 3.0, 0.0], [2.0, 2.0, 2.0])
+    assert shapes_distance(a, diagonal) == pytest.approx(SQRT2, abs=TOL)
+
+
+def test_oriented_boxes_separated_despite_overlapping_aabbs():
+    """Two 45 deg diamonds whose AABBs overlap but which are disjoint."""
+    yaw = rotation_from_euler(yaw=np.pi / 4)
+    a = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0], yaw)
+    b = Box([2.2, 2.2, 0.0], [2.0, 2.0, 2.0], yaw)
+
+    alo, ahi = a.aabb()
+    blo, bhi = b.aabb()
+    assert np.all(ahi >= blo) and np.all(bhi >= alo), "AABBs must overlap for this test"
+
+    assert not ref_obb_overlap(a, b)
+    assert not shapes_intersect(a, b)
+    # Corner-to-corner distance: sqrt(2) * (2.2 - sqrt(2)) = 2.2*sqrt(2) - 2.
+    assert shapes_distance(a, b) == pytest.approx(2.2 * SQRT2 - 2.0, abs=TOL)
+    assert shapes_distance(a, b) == pytest.approx(ref_obb_distance(a, b), abs=TOL)
+
+    # Sliding b in along the diagonal makes them overlap.
+    close = Box([1.3, 1.3, 0.0], [2.0, 2.0, 2.0], yaw)
+    assert ref_obb_overlap(a, close)
+    assert shapes_intersect(a, close)
+
+
+def test_oriented_boxes_random_against_reference():
+    rng = np.random.default_rng(23)
+    checked_separated = 0
+    checked_overlapping = 0
+    for _ in range(150):
+        a = Box(
+            rng.uniform(-1.5, 1.5, size=3),
+            rng.uniform(0.3, 2.0, size=3),
+            rotation_from_euler(*rng.uniform(-np.pi, np.pi, size=3)),
+        )
+        b = Box(
+            rng.uniform(-1.5, 1.5, size=3),
+            rng.uniform(0.3, 2.0, size=3),
+            rotation_from_euler(*rng.uniform(-np.pi, np.pi, size=3)),
+        )
+        overlap = ref_obb_overlap(a, b)
+        assert shapes_intersect(a, b) == overlap
+        if overlap:
+            assert shapes_distance(a, b) == 0.0
+            checked_overlapping += 1
+        else:
+            expected = ref_obb_distance(a, b)
+            assert shapes_distance(a, b) == pytest.approx(expected, abs=1e-9)
+            checked_separated += 1
+    assert checked_separated > 10 and checked_overlapping > 10
+
+
+# --------------------------------------------------------------------------- #
+# Capsules
+# --------------------------------------------------------------------------- #
+def test_capsule_sphere():
+    # Segment from (0,0,-1) to (0,0,1), radius 0.5.
+    capsule = Capsule([0.0, 0.0, 0.0], 0.5, 2.0)
+    a, b = capsule.segment()
+    assert np.allclose(a, [0.0, 0.0, -1.0]) and np.allclose(b, [0.0, 0.0, 1.0])
+
+    radial = Sphere([2.0, 0.0, 0.0], 0.25)
+    expected = ref_segment_segment_distance(a, b, radial.center, radial.center) - 0.75
+    assert shapes_distance(capsule, radial) == pytest.approx(expected, abs=TOL)
+    assert shapes_distance(capsule, radial) == pytest.approx(2.0 - 0.75, abs=TOL)
+
+    axial = Sphere([0.0, 0.0, 2.0], 0.25)
+    assert shapes_distance(capsule, axial) == pytest.approx(1.0 - 0.75, abs=TOL)
+
+    hit = Sphere([0.6, 0.0, 0.5], 0.25)
+    assert shapes_intersect(capsule, hit)
+    assert shapes_distance(capsule, hit) == 0.0
+
+    # Sphere beyond the cap, diagonally.
+    diagonal = Sphere([3.0, 0.0, 5.0], 0.5)
+    assert shapes_distance(capsule, diagonal) == pytest.approx(5.0 - 1.0, abs=TOL)
+
+
+def test_capsule_capsule_parallel_crossing_separated():
+    base = Capsule([0.0, 0.0, 0.0], 0.5, 2.0)
+    ba, bb = base.segment()
+
+    # Parallel, offset along x: segment distance is 3, radii sum to 1.
+    parallel = Capsule([3.0, 0.0, 0.0], 0.5, 2.0)
+    pa, pb = parallel.segment()
+    assert ref_segment_segment_distance(ba, bb, pa, pb) == pytest.approx(3.0, abs=TOL)
+    assert shapes_distance(base, parallel) == pytest.approx(2.0, abs=TOL)
+    assert not shapes_intersect(base, parallel)
+
+    # Crossing (rotated onto the X axis) and separated along z.
+    crossing = Capsule([0.0, 0.0, 3.0], 0.25, 2.0, rotation_from_euler(pitch=np.pi / 2))
+    ca, cb = crossing.segment()
+    seg = ref_segment_segment_distance(ba, bb, ca, cb)
+    assert seg == pytest.approx(2.0, abs=TOL)
+    assert shapes_distance(base, crossing) == pytest.approx(seg - 0.75, abs=TOL)
+    assert not shapes_intersect(base, crossing)
+
+    # Crossing and actually intersecting.
+    touching = Capsule([0.0, 0.0, 0.5], 0.25, 2.0, rotation_from_euler(pitch=np.pi / 2))
+    assert ref_segment_segment_distance(ba, bb, *touching.segment()) == pytest.approx(
+        0.0, abs=TOL
+    )
+    assert shapes_intersect(base, touching)
+    assert shapes_distance(base, touching) == 0.0
+
+    # Skew capsules: distance exactly equals radii-reduced segment distance.
+    skew = Capsule([1.0, 1.5, 0.0], 0.3, 3.0, rotation_from_euler(roll=np.pi / 2))
+    expected = max(0.0, ref_segment_segment_distance(ba, bb, *skew.segment()) - 0.8)
+    assert shapes_distance(base, skew) == pytest.approx(expected, abs=TOL)
+
+
+def test_capsule_capsule_random_against_segment_reference():
+    rng = np.random.default_rng(29)
+    for _ in range(200):
+        a = Capsule(
+            rng.uniform(-2.0, 2.0, size=3),
+            float(rng.uniform(0.05, 0.6)),
+            float(rng.uniform(0.0, 2.5)),
+            rotation_from_euler(*rng.uniform(-np.pi, np.pi, size=3)),
+        )
+        b = Capsule(
+            rng.uniform(-2.0, 2.0, size=3),
+            float(rng.uniform(0.05, 0.6)),
+            float(rng.uniform(0.0, 2.5)),
+            rotation_from_euler(*rng.uniform(-np.pi, np.pi, size=3)),
+        )
+        seg = ref_segment_segment_distance(*a.segment(), *b.segment())
+        expected = max(0.0, seg - a.radius - b.radius)
+        assert shapes_distance(a, b) == pytest.approx(expected, abs=1e-9)
+        if abs(expected) > 1e-6:
+            assert shapes_intersect(a, b) == (expected == 0.0)
+
+
+def test_capsule_box():
+    box = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    # Vertical capsule beside the box: purely radial separation.
+    beside = Capsule([2.5, 0.0, 0.0], 0.25, 1.0)
+    assert shapes_distance(beside, box) == pytest.approx(1.5 - 0.25, abs=TOL)
+    assert not shapes_intersect(beside, box)
+    # Long horizontal capsule that passes through the box.
+    through = Capsule([0.0, 0.0, 0.0], 0.1, 8.0, rotation_from_euler(pitch=np.pi / 2))
+    assert shapes_intersect(through, box)
+
+
+# --------------------------------------------------------------------------- #
+# Cylinder
+# --------------------------------------------------------------------------- #
+def test_cylinder_sphere_side_and_cap():
+    cylinder = Cylinder([0.0, 0.0, 0.0], 1.0, 2.0)  # z from -1 to 1
+
+    side = Sphere([3.0, 0.0, 0.0], 0.5)
+    assert shapes_distance(cylinder, side) == pytest.approx(3.0 - 1.0 - 0.5, abs=TOL)
+
+    cap = Sphere([0.0, 0.0, 2.5], 0.5)
+    assert shapes_distance(cylinder, cap) == pytest.approx(2.5 - 1.0 - 0.5, abs=TOL)
+
+    # Off-axis but still over the cap: distance stays purely axial.
+    over_cap = Sphere([0.4, 0.3, 2.0], 0.25)
+    assert shapes_distance(cylinder, over_cap) == pytest.approx(2.0 - 1.0 - 0.25, abs=TOL)
+
+    # Beyond the rim: distance to the circular edge.
+    rim = Sphere([2.0, 0.0, 2.0], 0.5)
+    assert shapes_distance(cylinder, rim) == pytest.approx(SQRT2 - 0.5, abs=TOL)
+
+    # Diagonal radial direction.
+    diagonal = Sphere([2.0, 2.0, 0.0], 0.25)
+    assert shapes_distance(cylinder, diagonal) == pytest.approx(
+        2.0 * SQRT2 - 1.0 - 0.25, abs=TOL
+    )
+
+    assert shapes_intersect(cylinder, Sphere([1.2, 0.0, 0.0], 0.25))
+    assert shapes_intersect(cylinder, Sphere([0.0, 0.0, 1.2], 0.25))
+    assert not shapes_intersect(cylinder, Sphere([1.4, 0.0, 0.0], 0.25))
+
+
+def test_rotated_cylinder_sphere():
+    # Axis along world X after a 90 deg pitch.
+    cylinder = Cylinder([0.0, 0.0, 0.0], 1.0, 4.0, rotation_from_euler(pitch=np.pi / 2))
+    along_axis = Sphere([4.0, 0.0, 0.0], 0.5)
+    assert shapes_distance(cylinder, along_axis) == pytest.approx(4.0 - 2.0 - 0.5, abs=TOL)
+    radial = Sphere([0.0, 0.0, 3.0], 0.5)
+    assert shapes_distance(cylinder, radial) == pytest.approx(3.0 - 1.0 - 0.5, abs=TOL)
+
+
+# --------------------------------------------------------------------------- #
+# Meshes
+# --------------------------------------------------------------------------- #
+def square_mesh(**kwargs):
+    """Unit square in the z = 0 plane built from two triangles."""
+    vertices = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    return Mesh(vertices, faces, **kwargs)
+
+
+def tetrahedron_mesh(**kwargs):
+    """Closed tetrahedron with unit legs at the origin."""
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    )
+    faces = np.array([[0, 2, 1], [0, 1, 3], [0, 3, 2], [1, 2, 3]])
+    return Mesh(vertices, faces, **kwargs)
+
+
+def l_shaped_mesh():
+    """Non-convex L in the z = 0 plane: [0,2]x[0,1] plus [0,1]x[1,2]."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [2.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 2.0, 0.0],
+            [0.0, 2.0, 0.0],
+        ]
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3], [3, 4, 5], [3, 5, 6]])
+    return Mesh(vertices, faces)
+
+
+def test_mesh_square_sphere():
+    mesh = square_mesh()
+    hit = Sphere([0.5, 0.5, 0.2], 0.3)
+    assert shapes_intersect(hit, mesh)
+    assert shapes_distance(hit, mesh) == 0.0
+
+    miss = Sphere([0.5, 0.5, 1.0], 0.3)
+    assert not shapes_intersect(miss, mesh)
+    assert shapes_distance(miss, mesh) == pytest.approx(0.7, abs=TOL)
+
+    # Off to the side: closest feature is the square's corner.
+    corner = Sphere([2.0, 2.0, 0.0], 0.5)
+    assert shapes_distance(corner, mesh) == pytest.approx(SQRT2 - 0.5, abs=TOL)
+
+    # Touching the surface exactly counts as a collision.
+    touching = Sphere([0.5, 0.5, 0.25], 0.25)
+    assert shapes_intersect(touching, mesh)
+
+
+def test_mesh_placement_is_honoured():
+    mesh = square_mesh(center=[0.0, 0.0, 5.0], rotation=rotation_from_euler(yaw=0.7), scale=2.0)
+    tris = mesh.triangles()
+    assert np.allclose(tris[:, :, 2], 5.0)
+    sphere = Sphere([0.0, 0.0, 6.0], 0.25)
+    # The scaled/rotated square still spans the origin corner, so the closest
+    # point is directly below the sphere on the z = 5 plane.
+    assert shapes_distance(sphere, mesh) == pytest.approx(0.75, abs=TOL)
+    assert shapes_intersect(Sphere([0.0, 0.0, 5.1], 0.25), mesh)
+
+
+def test_mesh_tetrahedron():
+    mesh = tetrahedron_mesh()
+    # Just outside the slanted face x + y + z = 1.
+    normal = np.ones(3) / SQRT3
+    outside = Sphere(normal * (1.0 / SQRT3 + 0.4), 0.2)
+    assert not shapes_intersect(outside, mesh)
+    assert shapes_distance(outside, mesh) == pytest.approx(0.2, abs=1e-9)
+
+    hitting = Sphere(normal * (1.0 / SQRT3 + 0.1), 0.2)
+    assert shapes_intersect(hitting, mesh)
+
+    far = Sphere([5.0, 5.0, 5.0], 1.0)
+    assert not shapes_intersect(far, mesh)
+
+    # A triangle soup is a surface, not a solid: a small sphere floating in the
+    # interior touches no triangle.
+    interior = Sphere([0.25, 0.25, 0.25], 0.05)
+    assert not shapes_intersect(interior, mesh)
+    assert shapes_distance(interior, mesh) == pytest.approx(0.25 / SQRT3 - 0.05, abs=1e-9)
+
+
+def test_non_convex_mesh_concavity_is_not_filled():
+    mesh = l_shaped_mesh()
+    probe = np.array([1.4, 1.4, 0.0])
+    # The notch point is 0.4 from the L but inside the convex hull.
+    small = Sphere(probe, 0.3)
+    assert not shapes_intersect(small, mesh)
+    assert shapes_distance(small, mesh) == pytest.approx(0.4 - 0.3, abs=TOL)
+    # gjk_distance uses Mesh.support, i.e. the convex hull, which does contain it.
+    assert gjk_distance(Sphere(probe, 0.0), mesh) == 0.0
+
+    big = Sphere(probe, 0.5)
+    assert shapes_intersect(big, mesh)
+    assert shapes_distance(big, mesh) == 0.0
+
+
+def test_non_convex_two_disjoint_triangles():
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0],
+            [4.0, 1.0, 0.0],
+        ]
+    )
+    mesh = Mesh(vertices, np.array([[0, 1, 2], [3, 4, 5]]))
+    between = Sphere([2.5, 0.0, 0.0], 0.5)
+    assert not shapes_intersect(between, mesh)
+    assert shapes_distance(between, mesh) == pytest.approx(1.5 - 0.5, abs=TOL)
+    assert shapes_intersect(Sphere([2.5, 0.0, 0.0], 1.6), mesh)
+
+
+def test_mesh_vs_mesh():
+    a = square_mesh()
+    stacked = square_mesh(center=[0.0, 0.0, 2.0])
+    assert shapes_distance(a, stacked) == pytest.approx(2.0, abs=TOL)
+    assert not shapes_intersect(a, stacked)
+
+    beside = square_mesh(center=[3.0, 0.0, 0.0])
+    assert shapes_distance(a, beside) == pytest.approx(2.0, abs=TOL)
+
+    crossing = square_mesh(center=[0.5, 0.5, -0.5], rotation=rotation_from_euler(roll=np.pi / 2))
+    assert shapes_intersect(a, crossing)
+    assert shapes_distance(a, crossing) == 0.0
+
+    assert shapes_intersect(a, square_mesh())
+
+
+def test_mesh_sphere_random_against_reference():
+    rng = np.random.default_rng(31)
+    meshes = [
+        square_mesh(center=[0.0, 0.0, 0.0]),
+        tetrahedron_mesh(center=[0.5, 0.0, 0.0], rotation=rotation_from_euler(0.2, 0.5, 1.0)),
+        l_shaped_mesh(),
+    ]
+    for mesh in meshes:
+        for _ in range(60):
+            sphere = Sphere(rng.uniform(-2.5, 2.5, size=3), float(rng.uniform(0.0, 0.6)))
+            expected = ref_mesh_sphere_distance(mesh, sphere)
+            assert shapes_distance(mesh, sphere) == pytest.approx(expected, abs=1e-9)
+            if abs(expected) > 1e-6:
+                assert shapes_intersect(mesh, sphere) == (expected == 0.0)
+
+
+def grid_mesh(n, **kwargs):
+    """``n`` x ``n`` grid of quads (2 n^2 triangles) in the z = 0 plane."""
+    coords = np.arange(n + 1) * 0.5
+    vertices = np.array([[x, y, 0.0] for x in coords for y in coords])
+    faces = []
+    for i in range(n):
+        for j in range(n):
+            v00 = i * (n + 1) + j
+            v10 = v00 + (n + 1)
+            faces += [[v00, v10, v10 + 1], [v00, v10 + 1, v00 + 1]]
+    return Mesh(vertices, np.array(faces), **kwargs)
+
+
+def test_mesh_mesh_many_triangles_against_reference():
+    """Exercises the AABB pruning on both loop levels (32 x 32 triangles)."""
+    a = grid_mesh(4)
+    b = grid_mesh(4, center=[0.7, 0.3, 2.0], rotation=rotation_from_euler(0.4, 0.2, 0.9))
+    expected = ref_mesh_mesh_distance(a, b)
+    assert expected > 0.0
+    assert shapes_distance(a, b) == pytest.approx(expected, abs=1e-9)
+    assert not shapes_intersect(a, b)
+
+    # Pushed together until the soups cross. ``a`` tiles the square
+    # [0, 2] x [0, 2] at z = 0, so an edge of ``c`` piercing that square inside
+    # those bounds proves the two surfaces intersect.
+    c = grid_mesh(4, center=[0.7, 0.3, 0.2], rotation=rotation_from_euler(0.4, 0.2, 0.9))
+    assert ref_edge_pierces_unit_square(c, z=0.0, hi=2.0)
+    assert shapes_intersect(a, c)
+    assert shapes_distance(a, c) == 0.0
+
+
+def test_mesh_without_faces_is_infinitely_far():
+    empty = Mesh(np.zeros((3, 3)), np.zeros((0, 3), dtype=int))
+    sphere = Sphere([0.0, 0.0, 0.0], 1.0)
+    assert shapes_distance(empty, sphere) == float("inf")
+    assert not shapes_intersect(empty, sphere)
+    assert shapes_distance(empty, Mesh(np.zeros((3, 3)), np.zeros((0, 3), dtype=int))) == float(
+        "inf"
+    )
+    assert shapes_distance(square_mesh(), empty) == float("inf")
+
+
+def test_mesh_vs_box_and_capsule():
+    mesh = square_mesh()
+    box = Box([0.5, 0.5, 1.5], [1.0, 1.0, 1.0])
+    assert shapes_distance(mesh, box) == pytest.approx(1.0, abs=TOL)
+    assert not shapes_intersect(mesh, box)
+    assert shapes_intersect(mesh, Box([0.5, 0.5, 0.4], [1.0, 1.0, 1.0]))
+
+    capsule = Capsule([0.5, 0.5, 1.0], 0.25, 1.0)
+    assert shapes_distance(mesh, capsule) == pytest.approx(0.5 - 0.25, abs=TOL)
+    assert shapes_intersect(mesh, Capsule([0.5, 0.5, 0.3], 0.25, 1.0))
+
+
+# --------------------------------------------------------------------------- #
+# Symmetry over a randomized sweep
+# --------------------------------------------------------------------------- #
+def random_shape(rng):
+    kind = rng.integers(0, 5)
+    centre = rng.uniform(-2.0, 2.0, size=3)
+    rotation = rotation_from_euler(*rng.uniform(-np.pi, np.pi, size=3))
+    if kind == 0:
+        return Sphere(centre, float(rng.uniform(0.0, 0.8)))
+    if kind == 1:
+        return Box(centre, rng.uniform(0.2, 1.6, size=3), rotation)
+    if kind == 2:
+        return Capsule(centre, float(rng.uniform(0.05, 0.6)), float(rng.uniform(0.0, 2.0)), rotation)
+    if kind == 3:
+        return Cylinder(centre, float(rng.uniform(0.1, 0.9)), float(rng.uniform(0.2, 2.0)), rotation)
+    mesh = rng.integers(0, 3)
+    if mesh == 0:
+        return square_mesh(center=centre, rotation=rotation, scale=float(rng.uniform(0.5, 2.0)))
+    if mesh == 1:
+        return tetrahedron_mesh(center=centre, rotation=rotation, scale=float(rng.uniform(0.5, 2.0)))
+    return Mesh(
+        l_shaped_mesh().vertices, l_shaped_mesh().faces, center=centre, rotation=rotation
+    )
+
+
+def test_symmetry_over_random_shape_pairs():
+    rng = np.random.default_rng(2024)
+    hits = 0
+    for _ in range(400):
+        a = random_shape(rng)
+        b = random_shape(rng)
+        dab = shapes_distance(a, b)
+        dba = shapes_distance(b, a)
+        assert dab == pytest.approx(dba, abs=1e-9)
+        iab = shapes_intersect(a, b)
+        assert iab == shapes_intersect(b, a)
+        hits += bool(iab)
+        if dab > 1e-7:
+            assert not iab
+        if dab == 0.0:
+            assert iab
+    # The sweep must actually exercise both branches.
+    assert 20 < hits < 380
+
+
+def test_distance_is_translation_invariant():
+    rng = np.random.default_rng(5)
+    for _ in range(50):
+        a = random_shape(rng)
+        b = random_shape(rng)
+        offset = rng.uniform(-10.0, 10.0, size=3)
+        assert shapes_distance(a, b) == pytest.approx(
+            shapes_distance(a.translated(offset), b.translated(offset)), abs=1e-8
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate shapes
+# --------------------------------------------------------------------------- #
+def test_zero_height_capsule_behaves_like_a_sphere():
+    capsule = Capsule([1.0, 2.0, 3.0], 0.4, 0.0)
+    sphere = Sphere([1.0, 2.0, 3.0], 0.4)
+    a, b = capsule.segment()
+    assert np.allclose(a, b)
+
+    probes = [
+        Sphere([4.0, 2.0, 3.0], 0.5),
+        Sphere([1.0, 2.0, 3.6], 0.2),
+        Box([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]),
+        Capsule([1.0, 2.0, 3.0], 0.1, 0.0),
+    ]
+    for probe in probes:
+        assert shapes_distance(capsule, probe) == pytest.approx(
+            shapes_distance(sphere, probe), abs=1e-9
+        )
+        assert shapes_intersect(capsule, probe) == shapes_intersect(sphere, probe)
+
+
+def test_zero_radius_sphere_is_a_point():
+    point = Sphere([2.0, 0.0, 0.0], 0.0)
+    box = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    assert shapes_distance(point, box) == pytest.approx(1.0, abs=TOL)
+    assert not shapes_intersect(point, box)
+
+    on_surface = Sphere([1.0, 0.0, 0.0], 0.0)
+    assert shapes_distance(on_surface, box) == pytest.approx(0.0, abs=TOL)
+    assert shapes_intersect(on_surface, box)
+
+    inside = Sphere([0.25, 0.25, 0.25], 0.0)
+    assert shapes_intersect(inside, box)
+    assert shapes_distance(inside, box) == 0.0
+
+    # Two coincident points.
+    assert shapes_intersect(point, Sphere([2.0, 0.0, 0.0], 0.0))
+    assert shapes_distance(point, Sphere([2.0, 1.0, 0.0], 0.0)) == pytest.approx(1.0, abs=TOL)
+
+
+def test_very_thin_box():
+    thin = Box([0.0, 0.0, 0.0], [1e-6, 2.0, 2.0])
+    near = Sphere([0.5, 0.0, 0.0], 0.25)
+    assert shapes_distance(near, thin) == pytest.approx(0.5 - 5e-7 - 0.25, abs=1e-9)
+    assert not shapes_intersect(near, thin)
+    assert shapes_intersect(Sphere([0.2, 0.0, 0.0], 0.25), thin)
+
+    # Thin box against a thin box, offset out of plane.
+    other = Box([0.25, 0.0, 0.0], [1e-6, 2.0, 2.0])
+    assert shapes_distance(thin, other) == pytest.approx(0.25 - 1e-6, abs=1e-9)
+    assert not shapes_intersect(thin, other)
+
+    # A degenerate (zero extent) box is a plane patch.
+    flat = Box([0.0, 0.0, 0.0], [0.0, 2.0, 2.0])
+    assert shapes_distance(Sphere([1.0, 0.0, 0.0], 0.25), flat) == pytest.approx(0.75, abs=TOL)
+    assert shapes_intersect(Sphere([0.1, 0.0, 0.0], 0.25), flat)
+
+    # A fully degenerate box collapses to a point.
+    dot = Box([1.0, 1.0, 1.0], [0.0, 0.0, 0.0])
+    assert shapes_distance(dot, Sphere([1.0, 1.0, 3.0], 0.5)) == pytest.approx(1.5, abs=TOL)
+
+
+@pytest.mark.parametrize("gap", [1e-3, 1e-5, 1e-7, 1e-9])
+def test_tiny_separations_are_resolved_not_snapped_to_zero(gap):
+    """Small positive distances must survive rather than collapse to contact."""
+    box = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+
+    other = Box([2.0 + gap, 0.0, 0.0], [2.0, 2.0, 2.0])
+    assert shapes_distance(box, other) == pytest.approx(gap, rel=1e-6)
+    assert not shapes_intersect(box, other)
+
+    sphere = Sphere([1.5 + gap, 0.0, 0.0], 0.5)
+    assert shapes_distance(box, sphere) == pytest.approx(gap, rel=1e-6)
+
+    # Same test along the diagonal of a rotated box, where the closest features
+    # are two corners rather than two faces.
+    yaw = rotation_from_euler(yaw=np.pi / 4)
+    a = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0], yaw)
+    b = Box([SQRT2 * (2.0 + gap), 0.0, 0.0], [2.0, 2.0, 2.0], yaw)
+    assert shapes_distance(a, b) == pytest.approx(SQRT2 * gap, rel=1e-5)
+
+    capsule = Capsule([0.0, 0.0, 0.0], 0.5, 2.0)
+    near = Capsule([1.0 + gap, 0.0, 0.0], 0.5, 2.0)
+    assert shapes_distance(capsule, near) == pytest.approx(gap, rel=1e-6)
+
+
+def test_zero_extent_capsule_and_cylinder_edge_cases():
+    # Zero-height cylinder is a disc.
+    disc = Cylinder([0.0, 0.0, 0.0], 1.0, 0.0)
+    assert shapes_distance(disc, Sphere([0.0, 0.0, 2.0], 0.5)) == pytest.approx(1.5, abs=TOL)
+    assert shapes_distance(disc, Sphere([3.0, 0.0, 0.0], 0.5)) == pytest.approx(1.5, abs=TOL)
+
+    # Zero-radius cylinder is a segment.
+    needle = Cylinder([0.0, 0.0, 0.0], 0.0, 2.0)
+    assert shapes_distance(needle, Sphere([2.0, 0.0, 0.0], 0.5)) == pytest.approx(1.5, abs=TOL)
+
+
+# --------------------------------------------------------------------------- #
+# GJK behaviour and integration with geometry.shapes_collide
+# --------------------------------------------------------------------------- #
+def test_triangle_wrapper_is_a_convex_shape():
+    """The internal triangle wrapper must satisfy the shape protocol GJK uses."""
+    verts = np.array([[0.0, 0.0, 1.0], [2.0, 0.0, 1.0], [0.0, 3.0, 1.0]])
+    tri = _Triangle(verts)
+    assert tri.margin == 0.0
+    assert np.allclose(tri.support(np.array([1.0, 0.0, 0.0])), verts[1])
+    assert np.allclose(tri.support(np.array([0.0, 1.0, 0.0])), verts[2])
+    assert np.allclose(tri.support(np.array([-1.0, -1.0, 0.0])), verts[0])
+    lo, hi = tri.aabb()
+    assert np.allclose(lo, [0.0, 0.0, 1.0])
+    assert np.allclose(hi, [2.0, 3.0, 1.0])
+    assert np.allclose(tri.core_points(), verts)
+    assert np.allclose(tri.center, verts.mean(axis=0))
+
+    # Triangles flow through the same GJK path as any other convex core.
+    assert gjk_distance(tri, Sphere([0.5, 0.5, 4.0], 0.0)) == pytest.approx(3.0, abs=TOL)
+    assert gjk_distance(tri, Box([0.5, 0.5, 3.0], [1.0, 1.0, 1.0])) == pytest.approx(
+        1.5, abs=TOL
+    )
+
+    # A cached AABB is reported verbatim.
+    cached = _Triangle().set_vertices(verts, np.full(3, -9.0), np.full(3, 9.0))
+    lo, hi = cached.aabb()
+    assert np.allclose(lo, -9.0) and np.allclose(hi, 9.0)
+
+
+def test_gjk_returns_zero_for_intersecting_cores():
+    a = Box([0.0, 0.0, 0.0], [2.0, 2.0, 2.0])
+    b = Box([0.5, 0.5, 0.5], [2.0, 2.0, 2.0], rotation_from_euler(0.3, 0.4, 0.5))
+    assert gjk_distance(a, b) == 0.0
+    # Cores touching at a single corner.
+    assert gjk_distance(a, Box([2.0, 2.0, 2.0], [2.0, 2.0, 2.0])) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_gjk_respects_max_iter_and_tolerance():
+    a = Cylinder([0.0, 0.0, 0.0], 1.0, 2.0, rotation_from_euler(0.3, 0.4, 0.5))
+    b = Sphere([4.0, 1.0, 0.5], 0.5)
+    exact = gjk_distance(a, b)
+    coarse = gjk_distance(a, b, max_iter=2, tol=1e-2)
+    assert coarse >= exact - 1e-12  # the simplex value is an upper bound
+    assert gjk_distance(a, b, max_iter=64, tol=1e-12) == pytest.approx(exact, abs=1e-9)
+
+
+def test_geometry_shapes_collide_delegates_here():
+    a = Sphere([0.0, 0.0, 0.0], 1.0)
+    b = Sphere([1.5, 0.0, 0.0], 1.0)
+    c = Box([4.0, 0.0, 0.0], [1.0, 1.0, 1.0])
+    assert shapes_collide(a, b) is shapes_intersect(a, b) is True
+    assert shapes_collide(a, c) is shapes_intersect(a, c) is False

--- a/tests/test_collision_rust.py
+++ b/tests/test_collision_rust.py
@@ -1,0 +1,410 @@
+"""Cross-checks of the native (Rust/parry3d) collision scene.
+
+Every test compares the native backend against the pure-Python GJK narrow
+phase in :mod:`krrtstar.collision`, which is the reference semantics. The two
+may legitimately disagree only for poses that sit exactly on a contact surface,
+so states whose signed clearance is within :data:`SURFACE_TOL` of zero are
+excluded from the comparison.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from krrtstar import accel
+from krrtstar.collision import shapes_distance
+from krrtstar.geometry import (
+    Box,
+    Capsule,
+    CollisionChecker,
+    Cylinder,
+    Environment,
+    Mesh,
+    PoseMapping,
+    Robot,
+    Sphere,
+    rotation_from_euler,
+)
+
+BOUNDS = np.array([[-10.0, -10.0, -10.0], [10.0, 10.0, 10.0]])
+
+#: Half-width of the ambiguous band around a contact surface.
+SURFACE_TOL = 1e-6
+
+
+def _native_scene_available() -> bool:
+    if not hasattr(accel, "make_collision_scene"):
+        return False
+    robot = Robot(shapes=[Sphere([0.0, 0.0, 0.0], 0.5)], pose=PoseMapping(x=0, y=1, z=2))
+    env = Environment(bounds=BOUNDS, obstacles=[Sphere([1.0, 0.0, 0.0], 0.5)])
+    return accel.make_collision_scene(robot, env) is not None
+
+
+pytestmark = pytest.mark.skipif(
+    not _native_scene_available(),
+    reason="native collision scene unavailable (build rust/ with maturin)",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _core_only(shape):
+    """Copy of ``shape`` with its margin removed, exposing the core set."""
+    if isinstance(shape, Sphere):
+        return Sphere(shape.center, 0.0)
+    if isinstance(shape, Capsule):
+        return Capsule(shape.center, 0.0, shape.height, shape.rotation)
+    return shape  # boxes, cylinders and meshes already have a zero margin
+
+
+def signed_clearance(robot: Robot, env: Environment, state) -> float:
+    """Signed distance from the robot to the nearest obstacle surface.
+
+    ``shapes_distance`` clamps overlap to zero, which cannot distinguish a
+    grazing contact from deep penetration. Comparing the *core* distance
+    against the summed margins keeps the sign, so the result is negative when
+    the shapes overlap and zero exactly on contact.
+    """
+    best = np.inf
+    for shape in robot.placed_shapes(state):
+        for obstacle in env.obstacles:
+            core = shapes_distance(_core_only(shape), _core_only(obstacle))
+            best = min(best, core - (float(shape.margin) + float(obstacle.margin)))
+    return float(best)
+
+
+def both_backends(robot: Robot, env: Environment):
+    """The native and pure-Python checkers for one robot/environment pair."""
+    native = CollisionChecker(robot, env, use_accel=True)
+    python = CollisionChecker(robot, env, use_accel=False)
+    assert native.backend == "rust"
+    assert python.backend == "python"
+    return native, python
+
+
+def assert_agree(robot, env, native, python, states):
+    """Both backends agree on every state outside the contact-surface band.
+
+    Returns ``(collisions, skipped)`` counted over ``states``.
+    """
+    collisions = 0
+    skipped = 0
+    for state in states:
+        got = native.in_collision(state)
+        want = python.in_collision(state)
+        if got != want:
+            gap = signed_clearance(robot, env, state)
+            assert abs(gap) <= SURFACE_TOL, (
+                f"backends disagree away from a contact surface at state {state}: "
+                f"rust={got}, python={want}, signed clearance={gap!r}"
+            )
+            skipped += 1
+            continue
+        collisions += int(want)
+    return collisions, skipped
+
+
+def sphere_robot(radius: float = 0.3) -> Robot:
+    return Robot(shapes=[Sphere([0.0, 0.0, 0.0], radius)], pose=PoseMapping(x=0, y=1, z=2))
+
+
+def sweep_states(
+    seed: int,
+    obstacles=(),
+    extent: float = 2.6,
+    grid_n: int = 6,
+    n_random: int = 220,
+    n_near: int = 220,
+    pad: float = 0.5,
+):
+    """A deterministic grid plus random positions, as ``(n, 6)`` states.
+
+    ``n_near`` extra positions are drawn from each obstacle's AABB inflated by
+    ``pad``, so a good share of the sweep lands close to a contact surface
+    instead of far out in free space.
+
+    The trailing three components are velocities the pose mapping ignores, so
+    the sweep also exercises the state -> pose index mapping.
+    """
+    rng = np.random.default_rng(seed)
+    axis = np.linspace(-extent, extent, grid_n)
+    grid = np.stack(np.meshgrid(axis, axis, axis, indexing="ij"), axis=-1).reshape(-1, 3)
+    blocks = [grid, rng.uniform(-extent, extent, size=(n_random, 3))]
+    for obstacle in obstacles:
+        lo, hi = obstacle.aabb()
+        blocks.append(rng.uniform(lo - pad, hi + pad, size=(n_near, 3)))
+    positions = np.vstack(blocks)
+    velocities = rng.normal(size=(positions.shape[0], 3))
+    return np.hstack([positions, velocities])
+
+
+def obstacle_cases() -> dict:
+    """One environment per obstacle shape type."""
+    return {
+        "sphere": Sphere([0.2, -0.1, 0.3], 1.1),
+        "box": Box([0.0, 0.0, 0.0], [2.0, 1.2, 1.6]),
+        "oriented_box": Box(
+            [0.4, -0.3, 0.1], [2.4, 1.0, 1.4], rotation_from_euler(yaw=np.pi / 4)
+        ),
+        "capsule": Capsule([0.1, 0.2, 0.0], 0.45, 1.8, rotation_from_euler(pitch=0.4)),
+        "cylinder": Cylinder([0.0, 0.3, -0.2], 0.7, 1.5, rotation_from_euler(roll=0.6)),
+        # A single triangle: an open, zero-thickness mesh.
+        "triangle_mesh": Mesh(
+            vertices=[[-1.0, -1.0, 0.0], [1.5, -0.5, 0.0], [0.0, 1.5, 0.5]],
+            faces=[[0, 1, 2]],
+            center=[0.0, 0.0, 0.2],
+            rotation=rotation_from_euler(roll=0.2, yaw=0.5),
+            scale=1.2,
+        ),
+        # A closed shell, which exercises the multi-triangle dispatch. The
+        # narrow phase is per-triangle on both sides, so only the shell itself
+        # collides, not the enclosed volume.
+        "tetrahedron_mesh": Mesh(
+            vertices=[[0.0, 0.0, 0.0], [1.6, 0.0, 0.0], [0.0, 1.6, 0.0], [0.0, 0.0, 1.6]],
+            faces=[[0, 2, 1], [0, 1, 3], [0, 3, 2], [1, 2, 3]],
+            center=[-0.6, -0.6, -0.4],
+            rotation=rotation_from_euler(pitch=0.3, yaw=0.8),
+            scale=1.1,
+        ),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Backend agreement over a randomized sweep
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name,obstacle", sorted(obstacle_cases().items()))
+def test_backends_agree_per_obstacle_type(name, obstacle):
+    robot = sphere_robot(0.3)
+    env = Environment(bounds=BOUNDS, obstacles=[obstacle])
+    native, python = both_backends(robot, env)
+
+    states = sweep_states(seed=20240816 + len(name), obstacles=env.obstacles)
+    collisions, skipped = assert_agree(robot, env, native, python, states)
+
+    n = len(states)
+    # The sweep must straddle the surface, otherwise agreement is vacuous.
+    assert min(collisions, n - collisions) >= 25, (
+        f"{name}: sweep did not span free and colliding regions "
+        f"({collisions}/{n} colliding)"
+    )
+    assert skipped <= 0.01 * n, f"{name}: too many ambiguous states ({skipped}/{n})"
+
+
+def test_backends_agree_with_multiple_obstacles():
+    robot = sphere_robot(0.35)
+    obstacles = list(obstacle_cases().values())
+    # Spread the obstacles out so several are reachable but not all overlapping.
+    offsets = [
+        [-2.0, -2.0, 0.0],
+        [2.0, 2.0, 0.5],
+        [-2.5, 2.0, -0.5],
+        [2.5, -2.0, 0.0],
+        [0.0, 0.0, 2.0],
+        [0.0, 0.0, -2.0],
+        [0.0, 2.5, 0.0],
+    ]
+    assert len(offsets) == len(obstacles)
+    env = Environment(
+        bounds=BOUNDS,
+        obstacles=[o.translated(d) for o, d in zip(obstacles, offsets)],
+    )
+    native, python = both_backends(robot, env)
+
+    states = sweep_states(
+        seed=99, obstacles=env.obstacles, extent=3.4, grid_n=7, n_random=200, n_near=80
+    )
+    collisions, skipped = assert_agree(robot, env, native, python, states)
+    assert min(collisions, len(states) - collisions) >= 25
+    assert skipped <= 0.01 * len(states)
+
+
+# --------------------------------------------------------------------------- #
+# Axis convention: capsules and cylinders are Z-aligned in the Python model
+# --------------------------------------------------------------------------- #
+def _axis_env(obstacle):
+    robot = sphere_robot(0.5)
+    return robot, Environment(bounds=BOUNDS, obstacles=[obstacle])
+
+
+@pytest.mark.parametrize(
+    "obstacle",
+    [
+        # Inner segment of length 4 -> the caps reach z = +-2.5.
+        Capsule([0.0, 0.0, 0.0], 0.5, 4.0),
+        # Full height of 4 -> the flat caps sit at z = +-2.
+        Cylinder([0.0, 0.0, 0.0], 0.5, 4.0),
+    ],
+    ids=["capsule", "cylinder"],
+)
+def test_z_axis_convention(obstacle):
+    robot, env = _axis_env(obstacle)
+    native, python = both_backends(robot, env)
+
+    on_axis = np.array([0.0, 0.0, 2.4, 0.0, 0.0, 0.0])
+    off_axis = np.array([3.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    # Would only collide if the shape's axis had been left on Y (parry's own
+    # convention) instead of being mapped back to Z.
+    swapped_axis = np.array([0.0, 2.4, 0.0, 0.0, 0.0, 0.0])
+    # Would only collide if `height` had been read as a half-height.
+    beyond_cap = np.array([0.0, 0.0, 3.5, 0.0, 0.0, 0.0])
+
+    for state, expected in [
+        (on_axis, True),
+        (off_axis, False),
+        (swapped_axis, False),
+        (beyond_cap, False),
+    ]:
+        assert python.in_collision(state) is expected
+        assert native.in_collision(state) is expected
+
+
+def test_capsule_height_excludes_end_caps():
+    """A capsule's ``height`` is the inner segment; a cylinder's is the total."""
+    robot = sphere_robot(0.25)
+    capsule = Environment(bounds=BOUNDS, obstacles=[Capsule([0.0] * 3, 0.5, 4.0)])
+    cylinder = Environment(bounds=BOUNDS, obstacles=[Cylinder([0.0] * 3, 0.5, 4.0)])
+
+    cap_native, cap_python = both_backends(robot, capsule)
+    cyl_native, cyl_python = both_backends(robot, cylinder)
+
+    # Capsule reaches z = 2.5, cylinder only z = 2, so z = 2.6 separates them.
+    state = np.array([0.0, 0.0, 2.6, 0.0, 0.0, 0.0])
+    assert cap_python.in_collision(state) is True
+    assert cap_native.in_collision(state) is True
+    assert cyl_python.in_collision(state) is False
+    assert cyl_native.in_collision(state) is False
+
+
+# --------------------------------------------------------------------------- #
+# The robot's orientation must be composed, not just its translation
+# --------------------------------------------------------------------------- #
+def oriented_robot(shapes) -> Robot:
+    return Robot(shapes=shapes, pose=PoseMapping(x=0, y=1, z=2, yaw=3))
+
+
+def test_robot_orientation_is_honoured():
+    robot = oriented_robot([Box([0.0, 0.0, 0.0], [4.0, 0.4, 0.4])])
+    env = Environment(bounds=BOUNDS, obstacles=[Sphere([1.5, 0.0, 0.0], 0.2)])
+    native, python = both_backends(robot, env)
+
+    aligned = np.array([0.0, 0.0, 0.0, 0.0])
+    turned = np.array([0.0, 0.0, 0.0, np.pi / 2])
+
+    assert python.in_collision(aligned) is True
+    assert native.in_collision(aligned) is True
+    assert python.in_collision(turned) is False
+    assert native.in_collision(turned) is False
+
+
+def test_robot_shape_offset_rotates_with_the_robot():
+    """A shape's own centre is rotated by the query, not merely translated."""
+    robot = oriented_robot([Sphere([1.5, 0.0, 0.0], 0.2)])
+    env = Environment(bounds=BOUNDS, obstacles=[Sphere([1.5, 0.0, 0.0], 0.2)])
+    native, python = both_backends(robot, env)
+
+    for yaw, expected in [(0.0, True), (np.pi / 2, False), (np.pi, False)]:
+        state = np.array([0.0, 0.0, 0.0, yaw])
+        assert python.in_collision(state) is expected
+        assert native.in_collision(state) is expected
+
+
+def test_backends_agree_for_an_oriented_robot():
+    robot = oriented_robot(
+        [Box([0.0, 0.0, 0.0], [3.0, 0.5, 0.5]), Sphere([1.2, 0.0, 0.0], 0.4)]
+    )
+    env = Environment(
+        bounds=BOUNDS,
+        obstacles=[
+            Box([1.6, 1.6, 0.0], [1.0, 1.0, 1.0], rotation_from_euler(yaw=np.pi / 4)),
+            Cylinder([-1.8, 0.6, 0.0], 0.5, 2.0, rotation_from_euler(pitch=0.3)),
+            Capsule([0.0, -2.2, 0.2], 0.4, 1.4),
+        ],
+    )
+    native, python = both_backends(robot, env)
+
+    rng = np.random.default_rng(7)
+    positions = rng.uniform(-3.0, 3.0, size=(260, 3))
+    yaws = rng.uniform(-np.pi, np.pi, size=(260, 1))
+    states = np.hstack([positions, yaws])
+
+    collisions, skipped = assert_agree(robot, env, native, python, states)
+    assert min(collisions, len(states) - collisions) >= 25
+    assert skipped <= 0.01 * len(states)
+
+
+# --------------------------------------------------------------------------- #
+# Trajectories
+# --------------------------------------------------------------------------- #
+def test_trajectory_in_collision_agrees():
+    robot = sphere_robot(0.3)
+    env = Environment(
+        bounds=BOUNDS,
+        obstacles=[
+            Sphere([0.0, 0.0, 0.0], 0.8),
+            Cylinder([2.5, 0.0, 0.0], 0.4, 1.2),
+            Capsule([-2.5, 0.0, 0.0], 0.3, 1.0, rotation_from_euler(pitch=np.pi / 2)),
+        ],
+    )
+    native, python = both_backends(robot, env)
+
+    def line(start, end, n=25):
+        ts = np.linspace(0.0, 1.0, n)[:, None]
+        positions = np.asarray(start, float) + ts * (
+            np.asarray(end, float) - np.asarray(start, float)
+        )
+        return np.hstack([positions, np.zeros((n, 3))])
+
+    trajectories = {
+        "through_the_sphere": (line([-4.0, 0.0, 0.0], [4.0, 0.0, 0.0]), True),
+        "clear_above": (line([-4.0, 0.0, 3.0], [4.0, 0.0, 3.0]), False),
+        "grazes_the_cylinder": (line([2.5, -4.0, 0.0], [2.5, 4.0, 0.0]), True),
+        "collides_at_the_first_pose": (line([0.0, 0.0, 0.0], [5.0, 5.0, 5.0]), True),
+        "collides_at_the_last_pose": (line([5.0, 5.0, 5.0], [0.0, 0.0, 0.0]), True),
+        "single_free_pose": (line([4.0, 4.0, 4.0], [4.0, 4.0, 4.0], n=1), False),
+    }
+
+    for name, (states, expected) in trajectories.items():
+        got = native.trajectory_in_collision(states)
+        want = python.trajectory_in_collision(states)
+        assert got == want, f"{name}: rust={got}, python={want}"
+        assert got is expected, f"{name}: expected {expected}, got {got}"
+
+
+def test_trajectory_in_collision_agrees_for_an_oriented_robot():
+    robot = oriented_robot([Box([0.0, 0.0, 0.0], [3.0, 0.4, 0.4])])
+    env = Environment(bounds=BOUNDS, obstacles=[Sphere([0.0, 1.2, 0.0], 0.3)])
+    native, python = both_backends(robot, env)
+
+    rng = np.random.default_rng(11)
+    for _ in range(30):
+        states = np.hstack(
+            [
+                rng.uniform(-2.5, 2.5, size=(12, 3)),
+                rng.uniform(-np.pi, np.pi, size=(12, 1)),
+            ]
+        )
+        assert native.trajectory_in_collision(states) == python.trajectory_in_collision(
+            states
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Native scene API
+# --------------------------------------------------------------------------- #
+def test_unknown_side_is_rejected():
+    import krrtstar_core
+
+    scene = krrtstar_core.CollisionScene()
+    with pytest.raises(ValueError):
+        scene.add_sphere("both", np.zeros(3), 1.0)
+
+
+def test_empty_scene_never_collides():
+    robot = sphere_robot(0.5)
+    env = Environment(bounds=BOUNDS, obstacles=[])
+    native = CollisionChecker(robot, env, use_accel=True)
+    assert native.backend == "rust"
+    assert native.in_collision(np.zeros(6)) is False
+    assert native.trajectory_in_collision(np.zeros((4, 6))) is False

--- a/tests/test_geometry_config.py
+++ b/tests/test_geometry_config.py
@@ -1,0 +1,221 @@
+"""Config-driven construction of the richer geometry types."""
+
+import os
+
+import numpy as np
+import pytest
+
+from krrtstar.config import (
+    build_collision_checker,
+    build_dynamics,
+    load_config,
+    parse_config,
+)
+from krrtstar.geometry import (
+    Box,
+    Capsule,
+    Cylinder,
+    Mesh,
+    Sphere,
+    load_mesh,
+    rotation_from_euler,
+)
+
+EXAMPLES = os.path.join(os.path.dirname(__file__), "..", "examples")
+RICH = os.path.join(EXAMPLES, "rich_geometry_3d.toml")
+BLOCK_OBJ = os.path.join(EXAMPLES, "assets", "block.obj")
+
+
+def _minimal(extra_env=None, robot=None):
+    data = {
+        "dynamics": {"x_dim": 2, "u_dim": 2},
+        "environment": {"bounds": [[-5, -5, -5], [5, 5, 5]]},
+    }
+    if extra_env:
+        data["environment"].update(extra_env)
+    if robot:
+        data["robot"] = robot
+    return data
+
+
+# --------------------------------------------------------------------------- #
+# Shape parsing
+# --------------------------------------------------------------------------- #
+def test_parses_every_shape_type():
+    cfg = parse_config(
+        _minimal(
+            {
+                "obstacles": [
+                    {"type": "sphere", "center": [0, 0, 0], "radius": 1.0},
+                    {"type": "box", "center": [1, 0, 0], "extents": [1, 2, 3]},
+                    {"type": "capsule", "center": [2, 0, 0], "radius": 0.5, "height": 2.0},
+                    {"type": "cylinder", "center": [3, 0, 0], "radius": 0.5, "height": 2.0},
+                ]
+            }
+        )
+    )
+    kinds = [type(o) for o in cfg.environment.obstacles]
+    assert kinds == [Sphere, Box, Capsule, Cylinder]
+    capsule = cfg.environment.obstacles[2]
+    assert capsule.radius == pytest.approx(0.5)
+    assert capsule.height == pytest.approx(2.0)
+
+
+def test_rejects_unknown_shape_type():
+    with pytest.raises(ValueError, match="Unsupported shape type"):
+        parse_config(_minimal({"obstacles": [{"type": "torus", "radius": 1}]}))
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"euler": [0.0, 0.0, np.pi / 2]},
+        {"rotation": [0.0, 0.0, np.pi / 2]},
+    ],
+)
+def test_orientation_from_euler_variants(spec):
+    entry = {"type": "box", "center": [0, 0, 0], "extents": [4, 1, 1], **spec}
+    cfg = parse_config(_minimal({"obstacles": [entry]}))
+    box = cfg.environment.obstacles[0]
+    assert np.allclose(box.rotation, rotation_from_euler(0.0, 0.0, np.pi / 2), atol=1e-12)
+    # a 90 degree yaw swings the long axis from X onto Y
+    lo, hi = box.aabb()
+    assert (hi - lo)[0] == pytest.approx(1.0, abs=1e-9)
+    assert (hi - lo)[1] == pytest.approx(4.0, abs=1e-9)
+
+
+def test_orientation_from_quaternion_and_matrix():
+    quat_cfg = parse_config(
+        _minimal({"obstacles": [
+            {"type": "box", "center": [0, 0, 0], "extents": [2, 1, 1],
+             "quaternion": [1.0, 0.0, 0.0, 0.0]}
+        ]})
+    )
+    assert np.allclose(quat_cfg.environment.obstacles[0].rotation, np.eye(3))
+
+    matrix_cfg = parse_config(
+        _minimal({"obstacles": [
+            {"type": "box", "center": [0, 0, 0], "extents": [2, 1, 1],
+             "rotation": [[0, -1, 0], [1, 0, 0], [0, 0, 1]]}
+        ]})
+    )
+    rot = matrix_cfg.environment.obstacles[0].rotation
+    assert np.allclose(rot @ np.array([1.0, 0.0, 0.0]), [0.0, 1.0, 0.0], atol=1e-12)
+
+
+def test_axis_aligned_box_has_identity_rotation():
+    cfg = parse_config(
+        _minimal({"obstacles": [{"type": "box", "center": [0, 0, 0], "extents": [1, 1, 1]}]})
+    )
+    assert cfg.environment.obstacles[0].is_axis_aligned()
+
+
+# --------------------------------------------------------------------------- #
+# Mesh loading
+# --------------------------------------------------------------------------- #
+def test_load_obj_reads_cube():
+    vertices, faces = load_mesh(BLOCK_OBJ)
+    assert vertices.shape == (8, 3)
+    assert faces.shape == (12, 3)  # 6 quads fan-triangulated
+    assert faces.min() >= 0 and faces.max() == 7
+
+
+def test_mesh_path_resolves_relative_to_config(tmp_path):
+    # A config in another directory must still find its asset by relative path.
+    cfg_path = tmp_path / "exp.toml"
+    cfg_path.write_text(
+        f"""
+[dynamics]
+x_dim = 2
+u_dim = 2
+
+[environment]
+bounds = [[-5,-5,-5],[5,5,5]]
+[[environment.obstacles]]
+type = "mesh"
+path = "{os.path.relpath(BLOCK_OBJ, tmp_path)}"
+center = [0,0,0]
+scale = 2.0
+"""
+    )
+    cfg = load_config(str(cfg_path))
+    mesh = cfg.environment.obstacles[0]
+    assert isinstance(mesh, Mesh)
+    assert mesh.scale == pytest.approx(2.0)
+    lo, hi = mesh.aabb()
+    # the 2x2x2 cube scaled by 2 spans [-2, 2] on every axis
+    assert np.allclose(lo, [-2, -2, -2], atol=1e-9)
+    assert np.allclose(hi, [2, 2, 2], atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Pose mapping with orientation
+# --------------------------------------------------------------------------- #
+def test_pose_mapping_reads_orientation_indices():
+    cfg = parse_config(
+        _minimal(robot={"pose_from_state": {"x": 0, "y": 1, "z": 2, "yaw": 3}})
+    )
+    pose = cfg.robot.pose
+    assert pose.has_orientation
+    state = np.array([1.0, 2.0, 3.0, np.pi / 2])
+    assert np.allclose(pose.position(state), [1, 2, 3])
+    assert np.allclose(pose.rotation(state) @ np.array([1.0, 0, 0]), [0, 1, 0], atol=1e-12)
+
+
+def test_pose_mapping_without_orientation_is_identity():
+    cfg = parse_config(_minimal(robot={"pose_from_state": {"x": 0, "y": 1}}))
+    pose = cfg.robot.pose
+    assert not pose.has_orientation
+    assert np.allclose(pose.rotation(np.array([1.0, 2.0])), np.eye(3))
+
+
+def test_oriented_robot_shape_follows_state_yaw():
+    cfg = parse_config(
+        _minimal(
+            {"obstacles": [{"type": "box", "center": [0, 2.0, 0], "extents": [0.4, 0.4, 0.4]}]},
+            robot={
+                "pose_from_state": {"x": 0, "y": 1, "yaw": 2},
+                "geometry": [{"type": "box", "center": [0, 0, 0], "extents": [4.0, 0.3, 0.3]}],
+            },
+        )
+    )
+    checker = build_collision_checker(cfg)
+    # A long bar at the origin: pointing along X it misses a block at y=2;
+    # rotated 90 degrees it reaches up and hits it.
+    assert not checker.in_collision(np.array([0.0, 0.0, 0.0]))
+    assert checker.in_collision(np.array([0.0, 0.0, np.pi / 2]))
+
+
+# --------------------------------------------------------------------------- #
+# The bundled rich-geometry example
+# --------------------------------------------------------------------------- #
+def test_rich_geometry_example_loads_and_collides():
+    cfg = load_config(RICH)
+    assert [type(o).__name__ for o in cfg.environment.obstacles] == [
+        "Box", "Cylinder", "Capsule", "Sphere", "Mesh",
+    ]
+    assert isinstance(cfg.robot.shapes[0], Capsule)
+    build_dynamics(cfg.dynamics)  # must be constructible
+
+    checker = build_collision_checker(cfg)
+    free = np.array([-7.0, -7.0, 0.0, 0, 0, 0])
+    inside_wall = np.array([0.0, 0.0, 0.0, 0, 0, 0])
+    inside_pillar = np.array([-4.0, 3.5, 0.0, 0, 0, 0])
+    assert not checker.in_collision(free)
+    assert checker.in_collision(inside_wall)
+    assert checker.in_collision(inside_pillar)
+
+
+def test_rich_geometry_example_plans():
+    from krrtstar.run import build_planner
+
+    cfg = load_config(RICH)
+    cfg.planner.target_nodes = 150
+    planner = build_planner(cfg)
+    result = planner.grow(cfg.planner.target_nodes)
+    assert len(result.tree.nodes) > 1
+    if result.found:
+        # Any returned solution must be collision free.
+        checker = build_collision_checker(cfg)
+        states = np.vstack([t.states for t in result.solution])
+        assert not checker.trajectory_in_collision(states)

--- a/tests/test_viz_shapes.py
+++ b/tests/test_viz_shapes.py
@@ -1,0 +1,205 @@
+"""Rendering of the full shape vocabulary (spheres, boxes, capsules, ...)."""
+
+import os
+
+import numpy as np
+import pytest
+
+pyvista = pytest.importorskip("pyvista")
+
+from krrtstar.config import load_config
+from krrtstar.geometry import (
+    Box,
+    Capsule,
+    Cylinder,
+    Mesh,
+    Sphere,
+    rotation_from_euler,
+)
+from krrtstar.run import build_planner
+from krrtstar.viz import _shape_to_mesh, render_result
+
+EXAMPLE = os.path.join(
+    os.path.dirname(__file__), "..", "examples", "double_integrator_2d.toml"
+)
+
+# Failures that indicate the headless VM lacks a working OpenGL / OSMesa stack.
+_HEADLESS_HINTS = (
+    "opengl",
+    "osmesa",
+    "glx",
+    "mesa",
+    "framebuffer",
+    "display",
+    "x11",
+    "xdisplay",
+    "render window",
+    "cannot connect",
+    "libgl",
+    "egl",
+)
+
+ROT_Z90 = rotation_from_euler(yaw=np.pi / 2)
+ROT_Y90 = rotation_from_euler(pitch=np.pi / 2)
+
+
+def _is_headless_failure(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return any(hint in text for hint in _HEADLESS_HINTS)
+
+
+def _square_mesh() -> Mesh:
+    """A unit square in the z=0 plane, as two triangles."""
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    return Mesh(vertices=vertices, faces=faces, center=[1.0, 2.0, 3.0])
+
+
+def _extents(mesh) -> np.ndarray:
+    """Side lengths of a mesh's axis-aligned bounding box."""
+    x0, x1, y0, y1, z0, z1 = (float(v) for v in mesh.bounds)
+    return np.array([x1 - x0, y1 - y0, z1 - z0])
+
+
+def _bounds_center(mesh) -> np.ndarray:
+    x0, x1, y0, y1, z0, z1 = (float(v) for v in mesh.bounds)
+    return np.array([(x0 + x1) / 2.0, (y0 + y1) / 2.0, (z0 + z1) / 2.0])
+
+
+SHAPES = {
+    "sphere": Sphere(center=[1.0, 2.0, 3.0], radius=0.75),
+    "box_axis_aligned": Box(center=[0.0, 0.0, 0.0], extents=[2.0, 1.0, 3.0]),
+    "box_oriented": Box(center=[1.0, 2.0, 3.0], extents=[2.0, 1.0, 3.0], rotation=ROT_Z90),
+    "capsule": Capsule(center=[0.0, 1.0, 0.0], radius=0.4, height=2.0, rotation=ROT_Y90),
+    "cylinder": Cylinder(center=[0.0, 0.0, 1.0], radius=0.5, height=2.0),
+    "mesh": _square_mesh(),
+}
+
+
+@pytest.mark.parametrize("name", sorted(SHAPES))
+def test_shape_to_mesh_is_renderable(name):
+    mesh = _shape_to_mesh(pyvista, SHAPES[name])
+    assert mesh is not None
+    assert mesh.n_points > 0, f"{name} produced an empty mesh"
+    assert np.all(np.isfinite(mesh.points))
+
+
+def test_unsupported_shape_raises_type_error():
+    with pytest.raises(TypeError):
+        _shape_to_mesh(pyvista, object())
+
+
+def test_oriented_box_is_rotated_and_positioned():
+    """A 90 deg yaw must swing the long axis onto Y without moving the center."""
+    box = Box(center=[5.0, 0.0, 0.0], extents=[4.0, 1.0, 1.0], rotation=ROT_Z90)
+    mesh = _shape_to_mesh(pyvista, box)
+
+    assert np.allclose(_bounds_center(mesh), [5.0, 0.0, 0.0], atol=1e-6)
+    assert np.allclose(_extents(mesh), [1.0, 4.0, 1.0], atol=1e-6)
+
+
+def test_axis_aligned_box_bounds():
+    box = Box(center=[-1.0, 2.0, 0.5], extents=[4.0, 1.0, 2.0])
+    mesh = _shape_to_mesh(pyvista, box)
+
+    assert np.allclose(_bounds_center(mesh), [-1.0, 2.0, 0.5], atol=1e-6)
+    assert np.allclose(_extents(mesh), [4.0, 1.0, 2.0], atol=1e-6)
+
+
+def test_capsule_bounds_follow_its_axis():
+    """height is the inner segment, so the Z span is height + 2 * radius."""
+    capsule = Capsule(center=[0.0, 0.0, 0.0], radius=0.5, height=4.0)
+    mesh = _shape_to_mesh(pyvista, capsule)
+
+    ex, ey, ez = _extents(mesh)
+    assert np.allclose(_bounds_center(mesh), [0.0, 0.0, 0.0], atol=1e-3)
+    # Tolerant on the exact tessellation, strict about which axis dominates.
+    assert ez > max(ex, ey) + 1.0
+    assert ez == pytest.approx(5.0, abs=0.1)
+    assert ex == pytest.approx(1.0, abs=0.1)
+    assert ey == pytest.approx(1.0, abs=0.1)
+
+
+def test_capsule_falls_back_to_cylinder_plus_caps(monkeypatch):
+    """Older PyVista versions have no Capsule; the union must still fit."""
+    monkeypatch.delattr(pyvista, "Capsule", raising=False)
+    capsule = Capsule(center=[0.0, 0.0, 0.0], radius=0.5, height=4.0)
+    mesh = _shape_to_mesh(pyvista, capsule)
+
+    ex, ey, ez = _extents(mesh)
+    assert mesh.n_points > 0
+    assert ez > max(ex, ey) + 1.0
+    assert ez == pytest.approx(5.0, abs=0.1)
+
+
+def test_cylinder_rotated_onto_x_axis():
+    cylinder = Cylinder(
+        center=[2.0, 0.0, 0.0], radius=0.5, height=3.0, rotation=ROT_Y90
+    )
+    mesh = _shape_to_mesh(pyvista, cylinder)
+
+    ex, ey, ez = _extents(mesh)
+    assert np.allclose(_bounds_center(mesh), [2.0, 0.0, 0.0], atol=1e-3)
+    assert ex == pytest.approx(3.0, abs=1e-3)
+    assert ey == pytest.approx(1.0, abs=1e-2)
+    assert ez == pytest.approx(1.0, abs=1e-2)
+
+
+def test_mesh_uses_world_vertices():
+    shape = _square_mesh()
+    mesh = _shape_to_mesh(pyvista, shape)
+
+    assert mesh.n_cells == 2
+    assert mesh.n_points == 4
+    assert np.allclose(
+        np.sort(mesh.points, axis=0),
+        np.sort(shape.world_vertices(), axis=0),
+        atol=1e-6,
+    )
+
+
+def test_render_scene_with_all_shape_types(tmp_path, monkeypatch):
+    """End-to-end offscreen render of a scene made of the new shape types."""
+    monkeypatch.setenv("PYVISTA_OFF_SCREEN", "true")
+
+    cfg = load_config(EXAMPLE)
+    cfg.planner.target_nodes = 30
+    cfg.environment.obstacles = [
+        Sphere(center=[2.0, 2.0, 0.0], radius=1.0),
+        Box(center=[-3.0, 1.0, 0.0], extents=[3.0, 1.0, 1.0], rotation=ROT_Z90),
+        Capsule(center=[0.0, -3.0, 0.0], radius=0.5, height=2.0, rotation=ROT_Y90),
+        Cylinder(center=[3.0, -2.0, 0.0], radius=0.8, height=2.0),
+        Mesh(
+            vertices=np.array(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+            ),
+            faces=np.array([[0, 1, 2], [0, 2, 3]]),
+            center=[-2.0, -3.0, 0.0],
+            scale=2.0,
+        ),
+    ]
+
+    planner = build_planner(cfg)
+    result = planner.grow(cfg.planner.target_nodes)
+
+    out_path = str(tmp_path / "out.png")
+    plotter = None
+    try:
+        plotter = render_result(
+            cfg, result, save_path=out_path, offscreen=True, show=False
+        )
+    except Exception as exc:  # noqa: BLE001 - we want to classify the failure
+        if _is_headless_failure(exc):
+            pytest.skip(f"headless rendering unavailable: {exc}")
+        raise
+    finally:
+        if plotter is not None:
+            try:
+                plotter.close()
+            except Exception:  # pragma: no cover - cleanup only
+                pass
+
+    assert os.path.exists(out_path), "screenshot PNG was not created"
+    assert os.path.getsize(out_path) > 0, "screenshot PNG is empty"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two of the three remaining follow-on items: **richer geometry** and **collision checking moved into Rust**. (Connection-radius schedule tuning is next, in its own PR.)

[3D scene with all supported shape types](https://cursor.com/agents/bc-019f2975-5a12-770d-9d09-6ed32a7e8d42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Frich_geometry.png)

*`examples/rich_geometry_3d.toml`: a capsule robot planning past an oriented wall (edge-on), a cylinder pillar, a capsule laid along X, a sphere, and a mesh cube loaded from OBJ.*

## Richer geometry

- **New shapes**: `Capsule`, `Cylinder`, and triangle `Mesh`, alongside `Sphere` and `Box`. Every shape can carry its own rotation, so **boxes may be oriented** — no longer AABB-only.
- **Robot orientation from the state**: `PoseMapping` now derives rotation from Euler indices (`roll`/`pitch`/`yaw`) or a quaternion, and placement composes a full rigid transform rather than a translation.
- **Mesh loading**: a minimal native OBJ reader, with other formats via `trimesh`/`pyvista` when installed. Mesh paths resolve relative to the config file.
- **Config**: all new shapes are config-driven, with rotation accepted as Euler angles, a quaternion, or a 3x3 matrix.

The unifying idea is that each shape is a convex **core** plus a **margin** (its round radius) — sphere is a point with radius, capsule a segment with radius, box/cylinder/mesh have zero margin. Two shapes intersect when their core distance is at most the sum of margins. That means a single support-function-based GJK path covers every convex pair instead of N² hand-written cases.

## Collision in Rust

- A native `parry3d` scene (`rust/src/collision.rs`, exposed as `CollisionScene`). Pose mapping deliberately stays in Python — the scene only sees geometry — so there's one source of truth for state→pose and no duplicated logic to drift.
- A pure-Python **GJK** narrow phase (`krrtstar/collision.py`) as the fallback, with exact closest-point-on-simplex routines; meshes are handled triangle-by-triangle with AABB pre-filtering.

**The two backends agree exactly.** Across thousands of sampled states covering every shape type (grids, uniform random, and positions concentrated near obstacle surfaces), there were **zero disagreements** — and no state even landed in the ambiguous near-contact band. Native is **~15x faster**: 1.9µs vs 29.2µs per query.

Accuracy of the Python engine is ~1e-15 on convex cases, validated against independent analytic references (point-to-OBB, segment-segment, SAT overlap, and exact feature enumeration for OBB/OBB and triangle/triangle).

## Known limitation worth flagging

**Meshes are surfaces, not filled solids.** A shape that fits entirely inside a closed mesh without touching a triangle is *not* in collision. For large hollow meshes a trajectory could pass through the interior, so prefer primitives for big volumes. This is documented in the geometry docstring, the README, and the plan; adding optional solid/containment semantics is listed as follow-on.

## Verification

- Tests: **135 passing, 1 skipped** (Torch). New coverage: 48 GJK tests against analytic ground truth, backend-agreement sweeps, config parsing for every shape and rotation form, mesh path resolution, oriented-robot collision, and rendering of each shape type (including a regression guard that an oriented box is both rotated *and* correctly positioned).
- The bundled rich-geometry example plans successfully (484 nodes, 6-D state) and its solution is asserted collision-free.
- The axis convention is pinned by tests: the Python model puts capsule/cylinder axes along local **Z** while parry3d uses **Y**, so the Rust side composes a Z→Y rotation. Deliberately mutating that mapping, the height semantics, or the row/column-major `rot9` read each fail multiple tests.

## Note

The legacy Visual Studio `.gitignore` was silently excluding `examples/assets/*.obj` as C++ object files, so the mesh asset wasn't being committed; added an exception.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2975-5a12-770d-9d09-6ed32a7e8d42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2975-5a12-770d-9d09-6ed32a7e8d42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

